### PR TITLE
Feature/#10 dropdown menu

### DIFF
--- a/src/components/dropdown/context.tsx
+++ b/src/components/dropdown/context.tsx
@@ -15,9 +15,9 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
   const isOpen = isControlled ? open : internalOpen;
 
   const setOpen = (value: boolean) => {
-    if (onOpenChange && typeof onOpenChange !== 'function')
+    if (!!onOpenChange && typeof onOpenChange !== 'function')
       console.warn('onOpenChange should be a function, ignoring invalid handler');
-    else if (onOpenChange) onOpenChange(value);
+    else if (!!onOpenChange) onOpenChange(value);
     if (isControlled) setInternalOpen(value);
   };
 

--- a/src/components/dropdown/context.tsx
+++ b/src/components/dropdown/context.tsx
@@ -15,7 +15,9 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
   const isOpen = isControlled ? open : internalOpen;
 
   const setOpen = (value: boolean) => {
-    if (onOpenChange) onOpenChange(value);
+    if (onOpenChange && typeof onOpenChange !== 'function')
+      console.warn('onOpenChange should be a function, ignoring invalid handler');
+    else if (onOpenChange) onOpenChange(value);
     if (open === undefined) setInternalOpen(value);
   };
 

--- a/src/components/dropdown/context.tsx
+++ b/src/components/dropdown/context.tsx
@@ -1,0 +1,34 @@
+import { createContext, useEffect, useState } from 'react';
+import { DropdownProps, DropdownContextType } from './type';
+
+export const dropdownContext = createContext<DropdownContextType>({
+  isOpen: false,
+  openMenu() {},
+  closeMenu() {},
+  toggleMenu() {}
+});
+
+const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }: DropdownProps) => {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : internalOpen;
+
+  const setOpen = (value: boolean) => {
+    if (onOpenChange) onOpenChange(value);
+    if (open === undefined) setInternalOpen(value);
+  };
+
+  const openMenu = () => setOpen(true);
+  const closeMenu = () => setOpen(false);
+  const toggleMenu = () => setOpen(!isOpen);
+
+  useEffect(() => {
+    if (open !== undefined) setInternalOpen(open);
+  }, [open]);
+
+  return (
+    <dropdownContext.Provider value={{ isOpen, openMenu, closeMenu, toggleMenu }}>{children}</dropdownContext.Provider>
+  );
+};
+export default DropdownProvider;

--- a/src/components/dropdown/context.tsx
+++ b/src/components/dropdown/context.tsx
@@ -23,7 +23,7 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
     if (!!onOpenChange && typeof onOpenChange !== 'function')
       console.warn('onOpenChange should be a function, ignoring invalid handler');
     else if (!!onOpenChange) onOpenChange(value);
-    if (isControlled) setInternalOpen(value);
+    if (!isControlled) setInternalOpen(value);
   };
 
   const openMenu = () => setOpen(true);

--- a/src/components/dropdown/context.tsx
+++ b/src/components/dropdown/context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState } from 'react';
+import { createContext, useState } from 'react';
 import { DropdownProps, DropdownContextType } from './type';
 
 export const dropdownContext = createContext<DropdownContextType>({
@@ -29,10 +29,6 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
   const openMenu = () => setOpen(true);
   const closeMenu = () => setOpen(false);
   const toggleMenu = () => setOpen(!isOpen);
-
-  useEffect(() => {
-    if (isControlled) setInternalOpen(open);
-  }, [isControlled, open]);
 
   return (
     <dropdownContext.Provider value={{ isOpen, openMenu, closeMenu, toggleMenu }}>{children}</dropdownContext.Provider>

--- a/src/components/dropdown/context.tsx
+++ b/src/components/dropdown/context.tsx
@@ -14,6 +14,11 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
   const isControlled = open !== undefined;
   const isOpen = isControlled ? open : internalOpen;
 
+  if (isControlled && !onOpenChange)
+    console.warn(
+      'You provided `open` prop without an `onOpenChange` handler. This will render a non-interactive dropdown component.'
+    );
+
   const setOpen = (value: boolean) => {
     if (!!onOpenChange && typeof onOpenChange !== 'function')
       console.warn('onOpenChange should be a function, ignoring invalid handler');

--- a/src/components/dropdown/context.tsx
+++ b/src/components/dropdown/context.tsx
@@ -18,7 +18,7 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
     if (onOpenChange && typeof onOpenChange !== 'function')
       console.warn('onOpenChange should be a function, ignoring invalid handler');
     else if (onOpenChange) onOpenChange(value);
-    if (open === undefined) setInternalOpen(value);
+    if (isControlled) setInternalOpen(value);
   };
 
   const openMenu = () => setOpen(true);
@@ -26,8 +26,8 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
   const toggleMenu = () => setOpen(!isOpen);
 
   useEffect(() => {
-    if (open !== undefined) setInternalOpen(open);
-  }, [open]);
+    if (isControlled) setInternalOpen(open);
+  }, [isControlled, open]);
 
   return (
     <dropdownContext.Provider value={{ isOpen, openMenu, closeMenu, toggleMenu }}>{children}</dropdownContext.Provider>

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -1,0 +1,7 @@
+import DropdownProvider from './context';
+import { DropdownProps } from './type';
+
+const DropdownComponent = ({ children, ...props }: DropdownProps) => {
+  return <DropdownProvider {...props}>{children}</DropdownProvider>;
+};
+export default DropdownComponent;

--- a/src/components/dropdown/index.ts
+++ b/src/components/dropdown/index.ts
@@ -1,0 +1,15 @@
+import DropdownComponent from './dropdown';
+import DropdownContent from './subcomponents/dropdown-content';
+import DropdownGroup from './subcomponents/dropdown-group';
+import DropdownItem from './subcomponents/dropdown-item';
+import DropdownSeparator from './subcomponents/dropdown-separator';
+import DropdownTrigger from './subcomponents/dropdown-trigger';
+
+const Dropdown = Object.assign(DropdownComponent, {
+  content: DropdownContent,
+  trigger: DropdownTrigger,
+  group: DropdownGroup,
+  item: DropdownItem,
+  separator: DropdownSeparator
+});
+export default Dropdown;

--- a/src/components/dropdown/subcomponents/dropdown-content.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-content.tsx
@@ -11,4 +11,6 @@ const DropdownContent = ({ children, style, ...props }: DropdownContentProps) =>
     </div>
   );
 };
+DropdownContent.displayName = 'dropdown-content';
+
 export default DropdownContent;

--- a/src/components/dropdown/subcomponents/dropdown-content.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-content.tsx
@@ -1,16 +1,17 @@
-import { useContext } from 'react';
+import { useContext, forwardRef } from 'react';
 import { dropdownContext } from '../context';
 import { DropdownContentProps } from '../type';
 
-const DropdownContent = ({ children, style, ...props }: DropdownContentProps) => {
+const DropdownContent = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, style, ...props }, ref) => {
   const { isOpen } = useContext(dropdownContext);
 
   return (
-    <div {...props} style={{ display: isOpen ? 'block' : 'none', ...style }}>
+    <div ref={ref} {...props} style={{ display: isOpen ? 'block' : 'none', ...style }}>
       {children}
     </div>
   );
-};
+});
+
 DropdownContent.displayName = 'dropdown-content';
 
 export default DropdownContent;

--- a/src/components/dropdown/subcomponents/dropdown-content.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-content.tsx
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+import { dropdownContext } from '../context';
+import { DropdownContentProps } from '../type';
+
+const DropdownContent = ({ children, style, ...props }: DropdownContentProps) => {
+  const { isOpen } = useContext(dropdownContext);
+
+  return (
+    <div {...props} style={{ display: isOpen ? 'block' : 'none', ...style }}>
+      {children}
+    </div>
+  );
+};
+export default DropdownContent;

--- a/src/components/dropdown/subcomponents/dropdown-group.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-group.tsx
@@ -1,0 +1,6 @@
+import { DropdownGroupProps } from '../type';
+
+const DropdownGroup = ({ children, ...props }: DropdownGroupProps) => {
+  return <ul {...props}>{children}</ul>;
+};
+export default DropdownGroup;

--- a/src/components/dropdown/subcomponents/dropdown-group.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-group.tsx
@@ -1,8 +1,14 @@
-import { DropdownGroupProps } from '../type';
+import { forwardRef } from 'react';
 
-const DropdownGroup = ({ children, ...props }: DropdownGroupProps) => {
-  return <ul {...props}>{children}</ul>;
-};
+type DropdownGroupProps = React.HtmlHTMLAttributes<HTMLUListElement> & {};
+
+const DropdownGroup = forwardRef<HTMLUListElement, DropdownGroupProps>(({ children, ...props }, ref) => {
+  return (
+    <ul ref={ref} {...props}>
+      {children}
+    </ul>
+  );
+});
 DropdownGroup.displayName = 'dropdown-group';
 
 export default DropdownGroup;

--- a/src/components/dropdown/subcomponents/dropdown-group.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-group.tsx
@@ -3,4 +3,6 @@ import { DropdownGroupProps } from '../type';
 const DropdownGroup = ({ children, ...props }: DropdownGroupProps) => {
   return <ul {...props}>{children}</ul>;
 };
+DropdownGroup.displayName = 'dropdown-group';
+
 export default DropdownGroup;

--- a/src/components/dropdown/subcomponents/dropdown-item.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-item.tsx
@@ -6,9 +6,9 @@ const DropdownItem = forwardRef<HTMLLIElement, DropdownItemProps>(({ children, o
   const { closeMenu } = useContext(dropdownContext);
 
   const handleDropdownItemClick = (e: React.MouseEvent<HTMLLIElement>) => {
-    if (onClick && typeof onClick !== 'function')
+    if (!!onClick && typeof onClick !== 'function')
       console.warn('onClick should be a function, ignoring invalid handler');
-    else if (onClick) onClick(e);
+    else if (!!onClick) onClick(e);
     closeMenu();
   };
 

--- a/src/components/dropdown/subcomponents/dropdown-item.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-item.tsx
@@ -16,4 +16,6 @@ const DropdownItem = ({ children, onClick, ...props }: DropdownItemProps) => {
     </li>
   );
 };
+DropdownItem.displayName = 'dropdown-item';
+
 export default DropdownItem;

--- a/src/components/dropdown/subcomponents/dropdown-item.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-item.tsx
@@ -1,0 +1,19 @@
+import { useContext } from 'react';
+import { dropdownContext } from '../context';
+import { DropdownItemProps } from '../type';
+
+const DropdownItem = ({ children, onClick, ...props }: DropdownItemProps) => {
+  const { closeMenu } = useContext(dropdownContext);
+
+  const handleDropdownItemClick = (e: React.MouseEvent<HTMLLIElement>) => {
+    if (onClick) onClick(e);
+    closeMenu();
+  };
+
+  return (
+    <li onClick={handleDropdownItemClick} {...props}>
+      {children}
+    </li>
+  );
+};
+export default DropdownItem;

--- a/src/components/dropdown/subcomponents/dropdown-item.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-item.tsx
@@ -1,8 +1,8 @@
-import { useContext } from 'react';
+import { forwardRef, useContext } from 'react';
 import { dropdownContext } from '../context';
 import { DropdownItemProps } from '../type';
 
-const DropdownItem = ({ children, onClick, ...props }: DropdownItemProps) => {
+const DropdownItem = forwardRef<HTMLLIElement, DropdownItemProps>(({ children, onClick, ...props }, ref) => {
   const { closeMenu } = useContext(dropdownContext);
 
   const handleDropdownItemClick = (e: React.MouseEvent<HTMLLIElement>) => {
@@ -13,11 +13,11 @@ const DropdownItem = ({ children, onClick, ...props }: DropdownItemProps) => {
   };
 
   return (
-    <li onClick={handleDropdownItemClick} {...props}>
+    <li onClick={handleDropdownItemClick} ref={ref} {...props}>
       {children}
     </li>
   );
-};
+});
 DropdownItem.displayName = 'dropdown-item';
 
 export default DropdownItem;

--- a/src/components/dropdown/subcomponents/dropdown-item.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-item.tsx
@@ -6,7 +6,9 @@ const DropdownItem = ({ children, onClick, ...props }: DropdownItemProps) => {
   const { closeMenu } = useContext(dropdownContext);
 
   const handleDropdownItemClick = (e: React.MouseEvent<HTMLLIElement>) => {
-    if (onClick) onClick(e);
+    if (onClick && typeof onClick !== 'function')
+      console.warn('onClick should be a function, ignoring invalid handler');
+    else if (onClick) onClick(e);
     closeMenu();
   };
 

--- a/src/components/dropdown/subcomponents/dropdown-separator.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-separator.tsx
@@ -1,8 +1,9 @@
+import { forwardRef } from 'react';
 import { DropdownSeparatorProps } from '../type';
 
-const DropdownSeparator = (props: DropdownSeparatorProps) => {
-  return <hr {...props} />;
-};
+const DropdownSeparator = forwardRef<HTMLHRElement, DropdownSeparatorProps>((props, ref) => {
+  return <hr ref={ref} {...props} />;
+});
 DropdownSeparator.displayName = 'dropdown-separator';
 
 export default DropdownSeparator;

--- a/src/components/dropdown/subcomponents/dropdown-separator.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-separator.tsx
@@ -1,0 +1,7 @@
+import { DropdownSeparatorProps } from '../type';
+
+const DropdownSeparator = (props: DropdownSeparatorProps) => {
+  return <hr {...props} />;
+};
+
+export default DropdownSeparator;

--- a/src/components/dropdown/subcomponents/dropdown-separator.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-separator.tsx
@@ -3,5 +3,6 @@ import { DropdownSeparatorProps } from '../type';
 const DropdownSeparator = (props: DropdownSeparatorProps) => {
   return <hr {...props} />;
 };
+DropdownSeparator.displayName = 'dropdown-separator';
 
 export default DropdownSeparator;

--- a/src/components/dropdown/subcomponents/dropdown-trigger.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-trigger.tsx
@@ -1,8 +1,8 @@
-import { useContext } from 'react';
+import { forwardRef, useContext } from 'react';
 import { dropdownContext } from '../context';
 import { DropdownTriggerProps } from '../type';
 
-const DropdownTrigger = ({ children, onClick, ...props }: DropdownTriggerProps) => {
+const DropdownTrigger = forwardRef<HTMLButtonElement, DropdownTriggerProps>(({ children, onClick, ...props }, ref) => {
   const { toggleMenu } = useContext(dropdownContext);
 
   const handleTriggerClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -13,11 +13,11 @@ const DropdownTrigger = ({ children, onClick, ...props }: DropdownTriggerProps) 
   };
 
   return (
-    <button onClick={handleTriggerClick} {...props}>
+    <button onClick={handleTriggerClick} ref={ref} {...props}>
       {children}
     </button>
   );
-};
+});
 DropdownTrigger.displayName = 'dropdown-trigger';
 
 export default DropdownTrigger;

--- a/src/components/dropdown/subcomponents/dropdown-trigger.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-trigger.tsx
@@ -6,7 +6,9 @@ const DropdownTrigger = ({ children, onClick, ...props }: DropdownTriggerProps) 
   const { toggleMenu } = useContext(dropdownContext);
 
   const handleTriggerClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (onClick) onClick(e);
+    if (onClick && typeof onClick !== 'function')
+      console.warn('onClick should be a function, ignoring invalid handler');
+    else if (onClick) onClick(e);
     toggleMenu();
   };
 

--- a/src/components/dropdown/subcomponents/dropdown-trigger.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-trigger.tsx
@@ -6,9 +6,9 @@ const DropdownTrigger = forwardRef<HTMLButtonElement, DropdownTriggerProps>(({ c
   const { toggleMenu } = useContext(dropdownContext);
 
   const handleTriggerClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (onClick && typeof onClick !== 'function')
+    if (!!onClick && typeof onClick !== 'function')
       console.warn('onClick should be a function, ignoring invalid handler');
-    else if (onClick) onClick(e);
+    else if (!!onClick) onClick(e);
     toggleMenu();
   };
 

--- a/src/components/dropdown/subcomponents/dropdown-trigger.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-trigger.tsx
@@ -1,0 +1,19 @@
+import { useContext } from 'react';
+import { dropdownContext } from '../context';
+import { DropdownTriggerProps } from '../type';
+
+const DropdownTrigger = ({ children, onClick, ...props }: DropdownTriggerProps) => {
+  const { toggleMenu } = useContext(dropdownContext);
+
+  const handleTriggerClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (onClick) onClick(e);
+    toggleMenu();
+  };
+
+  return (
+    <button onClick={handleTriggerClick} {...props}>
+      {children}
+    </button>
+  );
+};
+export default DropdownTrigger;

--- a/src/components/dropdown/subcomponents/dropdown-trigger.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-trigger.tsx
@@ -16,4 +16,6 @@ const DropdownTrigger = ({ children, onClick, ...props }: DropdownTriggerProps) 
     </button>
   );
 };
+DropdownTrigger.displayName = 'dropdown-trigger';
+
 export default DropdownTrigger;

--- a/src/components/dropdown/type.ts
+++ b/src/components/dropdown/type.ts
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+
+type DivProps = React.HTMLAttributes<HTMLDivElement>;
+type UlProps = React.HTMLAttributes<HTMLUListElement>;
+type LiProps = React.HTMLAttributes<HTMLLIElement>;
+type ButtonProps = React.HTMLAttributes<HTMLButtonElement>;
+type HrProps = React.HTMLAttributes<HTMLHRElement>;
+
+export type DropdownContentProps = DivProps & {};
+export type DropdownGroupProps = UlProps & {};
+export type DropdownItemProps = LiProps & {};
+export type DropdownTriggerProps = ButtonProps & {};
+export type DropdownSeparatorProps = HrProps & {};
+
+export type DropdownContextType = {
+  isOpen: boolean;
+  openMenu: () => void;
+  closeMenu: () => void;
+  toggleMenu: () => void;
+};
+
+export type DropdownProps = {
+  children: ReactNode;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #10 

<br>

## 📝 작업 내용

- Dropdown 컴포넌트의 하위 컴포넌트 선언
- Dropdown 메뉴의 기본 여는 기능 추가
- Dropdown 메뉴의 아이템 클릭 시 닫히는 기능 추가

<br>

## 🖼 스크린샷

https://github.com/user-attachments/assets/4654cc5e-6721-4fa3-b415-1233faf03063


<br>

## 💬 리뷰 요구사항
- 리뷰 예상 시간 : `10분`
- **[고민 사항]** 현재 `open` prop을 전달하면서 `onOpenChange`를 전달하지 않으면 워닝을 출력하고 있습니다. 매 렌더링 마다 해당 워닝이 출력되도록 되어 있는데요. 이를 useEffect를 사용하여 한번만 출력되도록 하는게 좋을까요?
- 코드 컨벤션을 보고 지키려고 했지만 놓친 부분이 있을 수도 있습니다!
- 혹시 다 같이 한번 확인해주시면 감사하겠습니다!
- 으아ㅠㅠ 커밋 컨벤션 안 지키고 있는거 마지막에 알았습니다ㅠㅠ 앞으로 잘 지키겠습니다ㅠㅠ
- 코드 사용 예시
```tsx
      <Dropdown>
        <Dropdown.trigger>click me!</Dropdown.trigger>
        <Dropdown.content>
          <Dropdown.group>
            <Dropdown.item>item 1</Dropdown.item>
            <Dropdown.item>item 2</Dropdown.item>
            <Dropdown.item>item 3</Dropdown.item>
            <Dropdown.separator />
            <Dropdown.item>item 4</Dropdown.item>
          </Dropdown.group>
        </Dropdown.content>
      </Dropdown>
```
- [참고 사진](https://react-spectrum.adobe.com/react-aria/useMenu.html#anatomy) 
![image](https://github.com/user-attachments/assets/e4dd0ffc-e853-41d5-9541-1f9292eab9aa)
- React Aria에서 명시하는 드롭다운의 구조는 위 사진과 같습니다.
- 저는 간단하게 아래와 같은 하위 컴포넌트들만 사용했습니다.
    - trigger
    - menu -> content
    - group
    - menu item -> item
    - separator (자체 추가 : group을 생성하지 않아도 ui 상으로 나눌 수 있게 추가했습니다.)
- 서브 아이템들은 기본 기능 구현 다하고 추가할 듯 합니다! 

다른 기능들은 새로운 PR 및 브랜치를 만들어서 하겠습니다!
