### PR TITLE
Feature/#13 tabs

### DIFF
--- a/src/components/tabs/context.tsx
+++ b/src/components/tabs/context.tsx
@@ -2,20 +2,32 @@ import { createContext, useState } from 'react';
 import { TabsContextType, TabsProviderProps } from './type';
 
 export const TabsContext = createContext<TabsContextType>({
-  activeTab: '',
+  activeTab: undefined,
   handleChange() {}
 });
 
 export const TabsProvider = ({ children, defaultTab, tab, onChange }: TabsProviderProps) => {
-  const initialTab = defaultTab || '';
-  const [internalTab, setInternalTab] = useState<string>(initialTab);
+  const [internalTab, setInternalTab] = useState<string | undefined>(defaultTab);
 
-  const isControlled = !!tab;
-  const activeTab = isControlled ? tab || initialTab : internalTab;
+  if (defaultTab === undefined && tab === undefined) {
+    console.warn(`Tabs: No children found in 'TabGroup' and neither 'defaultTab' nor 'tab' value provided.`);
+  }
+
+  if (tab !== undefined && typeof tab !== 'string') {
+    console.warn(`Tabs: 'tab' prop should be a string, but received '${typeof tab}'.`);
+  }
+
+  const isControlled = tab !== undefined;
+  const activeTab = isControlled ? tab : internalTab;
 
   const handleChange = (newTab: string) => {
     if (!isControlled) setInternalTab(newTab);
-    if (onChange) onChange(newTab);
+    if (onChange === undefined) return;
+    if (typeof onChange !== 'function') {
+      console.warn(`onChange: 'onChange' prop should be a function, but received '${typeof onChange}'.`);
+    } else {
+      onChange(newTab);
+    }
   };
 
   return <TabsContext.Provider value={{ activeTab, handleChange }}>{children}</TabsContext.Provider>;

--- a/src/components/tabs/context.tsx
+++ b/src/components/tabs/context.tsx
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+
+/**
+ * context 타입
+ */
+interface TabsContextType {
+  activeTabId: string | null;
+  setActiveTabId: ((id: string) => void) | null;
+}
+
+const initialValue = {
+  activeTabId: null,
+  setActiveTabId: null
+};
+
+export const TabsContext = createContext<TabsContextType>(initialValue);

--- a/src/components/tabs/context.tsx
+++ b/src/components/tabs/context.tsx
@@ -1,16 +1,13 @@
-import { createContext } from 'react';
+import { createContext, useState } from 'react';
+import { TabsContextType, TabsProviderProps } from './type';
 
-/**
- * context 타입
- */
-interface TabsContextType {
-  activeTabId: string | null;
-  setActiveTabId: ((id: string) => void) | null;
-}
+export const TabsContext = createContext<TabsContextType>({
+  activeTab: '',
+  setActiveTab: () => {}
+});
 
-const initialValue = {
-  activeTabId: null,
-  setActiveTabId: null
+export const TabsProvider = ({ children, defaultTab }: TabsProviderProps) => {
+  const [activeTab, setActiveTab] = useState<string>(defaultTab);
+
+  return <TabsContext.Provider value={{ activeTab, setActiveTab }}>{children}</TabsContext.Provider>;
 };
-
-export const TabsContext = createContext<TabsContextType>(initialValue);

--- a/src/components/tabs/context.tsx
+++ b/src/components/tabs/context.tsx
@@ -3,11 +3,20 @@ import { TabsContextType, TabsProviderProps } from './type';
 
 export const TabsContext = createContext<TabsContextType>({
   activeTab: '',
-  setActiveTab: () => {}
+  handleChange() {}
 });
 
-export const TabsProvider = ({ children, defaultTab }: TabsProviderProps) => {
-  const [activeTab, setActiveTab] = useState<string>(defaultTab);
+export const TabsProvider = ({ children, defaultTab, tab, onChange }: TabsProviderProps) => {
+  const initialTab = defaultTab || '';
+  const [internalTab, setInternalTab] = useState<string>(initialTab);
 
-  return <TabsContext.Provider value={{ activeTab, setActiveTab }}>{children}</TabsContext.Provider>;
+  const isControlled = !!tab;
+  const activeTab = isControlled ? tab || initialTab : internalTab;
+
+  const handleChange = (newTab: string) => {
+    if (!isControlled) setInternalTab(newTab);
+    if (onChange) onChange(newTab);
+  };
+
+  return <TabsContext.Provider value={{ activeTab, handleChange }}>{children}</TabsContext.Provider>;
 };

--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -1,0 +1,14 @@
+import Content from './subcomponents/content';
+import ContentGroup from './subcomponents/content-group';
+import Tab from './subcomponents/tab';
+import TabGroup from './subcomponents/tab-group';
+import TabsComponent from './tabs';
+
+const Tabs = Object.assign(TabsComponent, {
+  tabGroup: TabGroup,
+  tab: Tab,
+  contentGroup: ContentGroup,
+  content: Content
+});
+
+export default Tabs;

--- a/src/components/tabs/subcomponents/content-group.tsx
+++ b/src/components/tabs/subcomponents/content-group.tsx
@@ -1,7 +1,7 @@
 import { ContentGroupProps } from '../type';
 
-const ContentGroup = ({ children }: ContentGroupProps) => {
-  return <div>{children}</div>;
+const ContentGroup = ({ children, ...props }: ContentGroupProps) => {
+  return <div {...props}>{children}</div>;
 };
 
 export default ContentGroup;

--- a/src/components/tabs/subcomponents/content-group.tsx
+++ b/src/components/tabs/subcomponents/content-group.tsx
@@ -1,5 +1,7 @@
-const ContentGroup = () => {
-  return <></>;
+import { ContentGroupProps } from '../type';
+
+const ContentGroup = ({ children }: ContentGroupProps) => {
+  return <div>{children}</div>;
 };
 
 export default ContentGroup;

--- a/src/components/tabs/subcomponents/content-group.tsx
+++ b/src/components/tabs/subcomponents/content-group.tsx
@@ -1,0 +1,5 @@
+const ContentGroup = () => {
+  return <></>;
+};
+
+export default ContentGroup;

--- a/src/components/tabs/subcomponents/content.tsx
+++ b/src/components/tabs/subcomponents/content.tsx
@@ -3,9 +3,9 @@ import { ContentProps } from '../type';
 import { TabsContext } from '../context';
 
 const Content = ({ children, id }: ContentProps) => {
-  const { activeTabId } = useContext(TabsContext);
+  const { activeTab } = useContext(TabsContext);
 
-  if (activeTabId !== id) return null;
+  if (activeTab !== id) return null;
 
   return <div>{children}</div>;
 };

--- a/src/components/tabs/subcomponents/content.tsx
+++ b/src/components/tabs/subcomponents/content.tsx
@@ -1,5 +1,13 @@
-const Content = () => {
-  return <></>;
+import { useContext } from 'react';
+import { ContentProps } from '../type';
+import { TabsContext } from '../context';
+
+const Content = ({ children, id }: ContentProps) => {
+  const { activeTabId } = useContext(TabsContext);
+
+  if (activeTabId !== id) return null;
+
+  return <div>{children}</div>;
 };
 
 export default Content;

--- a/src/components/tabs/subcomponents/content.tsx
+++ b/src/components/tabs/subcomponents/content.tsx
@@ -2,12 +2,16 @@ import { useContext } from 'react';
 import { ContentProps } from '../type';
 import { TabsContext } from '../context';
 
-const Content = ({ children, id }: ContentProps) => {
+const Content = ({ children, id, ...props }: ContentProps) => {
   const { activeTab } = useContext(TabsContext);
 
   if (activeTab !== id) return null;
 
-  return <div>{children}</div>;
+  return (
+    <div role="tabpanel" {...props}>
+      {children}
+    </div>
+  );
 };
 
 export default Content;

--- a/src/components/tabs/subcomponents/content.tsx
+++ b/src/components/tabs/subcomponents/content.tsx
@@ -5,6 +5,11 @@ import { TabsContext } from '../context';
 const Content = ({ children, id, ...props }: ContentProps) => {
   const { activeTab } = useContext(TabsContext);
 
+  if (typeof id !== 'string') {
+    console.warn(`Tabs: 'id' prop should be a string, but received '${typeof id}'.`);
+    return null;
+  }
+
   if (activeTab !== id) return null;
 
   return (

--- a/src/components/tabs/subcomponents/content.tsx
+++ b/src/components/tabs/subcomponents/content.tsx
@@ -1,0 +1,5 @@
+const Content = () => {
+  return <></>;
+};
+
+export default Content;

--- a/src/components/tabs/subcomponents/tab-group.tsx
+++ b/src/components/tabs/subcomponents/tab-group.tsx
@@ -1,7 +1,11 @@
 import { TabGroupProps } from '../type';
 
-const TabGroup = ({ children }: TabGroupProps) => {
-  return <div>{children}</div>;
+const TabGroup = ({ children, ...props }: TabGroupProps) => {
+  return (
+    <ul role="tablist" {...props}>
+      {children}
+    </ul>
+  );
 };
 
 export default TabGroup;

--- a/src/components/tabs/subcomponents/tab-group.tsx
+++ b/src/components/tabs/subcomponents/tab-group.tsx
@@ -1,5 +1,7 @@
-const TabGroup = () => {
-  return <></>;
+import { TabGroupProps } from '../type';
+
+const TabGroup = ({ children }: TabGroupProps) => {
+  return <div>{children}</div>;
 };
 
 export default TabGroup;

--- a/src/components/tabs/subcomponents/tab-group.tsx
+++ b/src/components/tabs/subcomponents/tab-group.tsx
@@ -1,0 +1,5 @@
+const TabGroup = () => {
+  return <></>;
+};
+
+export default TabGroup;

--- a/src/components/tabs/subcomponents/tab.tsx
+++ b/src/components/tabs/subcomponents/tab.tsx
@@ -1,0 +1,5 @@
+const Tab = () => {
+  return <></>;
+};
+
+export default Tab;

--- a/src/components/tabs/subcomponents/tab.tsx
+++ b/src/components/tabs/subcomponents/tab.tsx
@@ -1,9 +1,15 @@
-import { useContext } from 'react';
+import { ElementType, useContext } from 'react';
 import { TabProps } from '../type';
 import { TabsContext } from '../context';
 
-const Tab = ({ children, id, as: Tag = 'button', ...props }: TabProps) => {
+const Tab = <T extends keyof HTMLElementTagNameMap = 'button'>({
+  children,
+  id,
+  as = 'button' as T,
+  ...props
+}: TabProps<T>) => {
   const { handleChange } = useContext(TabsContext);
+  const Tag = as as ElementType;
 
   if (typeof id !== 'string') {
     console.warn(`Tabs: 'id' prop should be a string, but received '${typeof id}'.`);

--- a/src/components/tabs/subcomponents/tab.tsx
+++ b/src/components/tabs/subcomponents/tab.tsx
@@ -2,10 +2,16 @@ import { useContext } from 'react';
 import { TabProps } from '../type';
 import { TabsContext } from '../context';
 
-const Tab = ({ children, id }: TabProps) => {
-  const { setActiveTab } = useContext(TabsContext);
+const Tab = ({ children, id, ...props }: TabProps) => {
+  const { handleChange } = useContext(TabsContext);
 
-  return <button onClick={() => setActiveTab(id)}>{children}</button>;
+  return (
+    <li role="presentation">
+      <button role="tab" onClick={() => handleChange(id)} {...props}>
+        {children}
+      </button>
+    </li>
+  );
 };
 
 export default Tab;

--- a/src/components/tabs/subcomponents/tab.tsx
+++ b/src/components/tabs/subcomponents/tab.tsx
@@ -2,14 +2,18 @@ import { useContext } from 'react';
 import { TabProps } from '../type';
 import { TabsContext } from '../context';
 
-const Tab = ({ children, id, ...props }: TabProps) => {
+const Tab = ({ children, id, as: Tag = 'button', ...props }: TabProps) => {
   const { handleChange } = useContext(TabsContext);
+
+  if (typeof id !== 'string') {
+    console.warn(`Tabs: 'id' prop should be a string, but received '${typeof id}'.`);
+  }
 
   return (
     <li role="presentation">
-      <button role="tab" onClick={() => handleChange(id)} {...props}>
+      <Tag role="tab" onClick={() => handleChange(id)} {...props}>
         {children}
-      </button>
+      </Tag>
     </li>
   );
 };

--- a/src/components/tabs/subcomponents/tab.tsx
+++ b/src/components/tabs/subcomponents/tab.tsx
@@ -1,16 +1,11 @@
 import { useContext } from 'react';
 import { TabProps } from '../type';
 import { TabsContext } from '../context';
-import '../style.css';
 
 const Tab = ({ children, id }: TabProps) => {
-  const { setActiveTabId } = useContext(TabsContext);
+  const { setActiveTab } = useContext(TabsContext);
 
-  return (
-    <button className="tab-button" onClick={() => setActiveTabId?.(id)}>
-      {children}
-    </button>
-  );
+  return <button onClick={() => setActiveTab(id)}>{children}</button>;
 };
 
 export default Tab;

--- a/src/components/tabs/subcomponents/tab.tsx
+++ b/src/components/tabs/subcomponents/tab.tsx
@@ -1,5 +1,16 @@
-const Tab = () => {
-  return <></>;
+import { useContext } from 'react';
+import { TabProps } from '../type';
+import { TabsContext } from '../context';
+import '../style.css';
+
+const Tab = ({ children, id }: TabProps) => {
+  const { setActiveTabId } = useContext(TabsContext);
+
+  return (
+    <button className="tab-button" onClick={() => setActiveTabId?.(id)}>
+      {children}
+    </button>
+  );
 };
 
 export default Tab;

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -1,0 +1,5 @@
+const Tabs = () => {
+  return <></>;
+};
+
+export default Tabs;

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -1,27 +1,19 @@
-import { useState } from 'react';
-import { TabsContext } from './context';
+import { TabsProvider } from './context';
 import Content from './subcomponents/content';
 import ContentGroup from './subcomponents/content-group';
 import Tab from './subcomponents/tab';
 import TabGroup from './subcomponents/tab-group';
-import { TabsContainerProps } from './type';
+import { TabsComponentProps } from './type';
 
-/**
- * Tabs 전체 컨테이너
- */
-const TabsContainer = ({ children, defaultTabId }: TabsContainerProps) => {
-  const [activeTabId, setActiveTabId] = useState(defaultTabId);
-  return <TabsContext.Provider value={{ activeTabId, setActiveTabId }}>{children}</TabsContext.Provider>;
+const TabsComponent = ({ children, defaultTab }: TabsComponentProps) => {
+  return <TabsProvider defaultTab={defaultTab}>{children}</TabsProvider>;
 };
 
-/**
- * Tabs 컴파운드 컴포넌트
- */
-const Tabs = Object.assign(TabsContainer, {
-  TabGroup,
-  Tab,
-  ContentGroup,
-  Content
+const Tabs = Object.assign(TabsComponent, {
+  tabGroup: TabGroup,
+  tab: Tab,
+  contentGroup: ContentGroup,
+  content: Content
 });
 
 export default Tabs;

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -1,19 +1,15 @@
 import { TabsProvider } from './context';
-import Content from './subcomponents/content';
-import ContentGroup from './subcomponents/content-group';
-import Tab from './subcomponents/tab';
-import TabGroup from './subcomponents/tab-group';
 import { TabsComponentProps } from './type';
+import { findFirstTabId } from './utils';
 
-const TabsComponent = ({ children, ...props }: TabsComponentProps) => {
-  return <TabsProvider {...props}>{children}</TabsProvider>;
+const TabsComponent = ({ children, defaultTab, ...props }: TabsComponentProps) => {
+  const initialTab = defaultTab === undefined ? findFirstTabId(children) : defaultTab;
+
+  return (
+    <TabsProvider defaultTab={initialTab} {...props}>
+      {children}
+    </TabsProvider>
+  );
 };
 
-const Tabs = Object.assign(TabsComponent, {
-  tabGroup: TabGroup,
-  tab: Tab,
-  contentGroup: ContentGroup,
-  content: Content
-});
-
-export default Tabs;
+export default TabsComponent;

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -5,8 +5,8 @@ import Tab from './subcomponents/tab';
 import TabGroup from './subcomponents/tab-group';
 import { TabsComponentProps } from './type';
 
-const TabsComponent = ({ children, defaultTab }: TabsComponentProps) => {
-  return <TabsProvider defaultTab={defaultTab}>{children}</TabsProvider>;
+const TabsComponent = ({ children, ...props }: TabsComponentProps) => {
+  return <TabsProvider {...props}>{children}</TabsProvider>;
 };
 
 const Tabs = Object.assign(TabsComponent, {

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -1,5 +1,27 @@
-const Tabs = () => {
-  return <></>;
+import { useState } from 'react';
+import { TabsContext } from './context';
+import Content from './subcomponents/content';
+import ContentGroup from './subcomponents/content-group';
+import Tab from './subcomponents/tab';
+import TabGroup from './subcomponents/tab-group';
+import { TabsContainerProps } from './type';
+
+/**
+ * Tabs 전체 컨테이너
+ */
+const TabsContainer = ({ children, defaultTabId }: TabsContainerProps) => {
+  const [activeTabId, setActiveTabId] = useState(defaultTabId);
+  return <TabsContext.Provider value={{ activeTabId, setActiveTabId }}>{children}</TabsContext.Provider>;
 };
+
+/**
+ * Tabs 컴파운드 컴포넌트
+ */
+const Tabs = Object.assign(TabsContainer, {
+  TabGroup,
+  Tab,
+  ContentGroup,
+  Content
+});
 
 export default Tabs;

--- a/src/components/tabs/type.ts
+++ b/src/components/tabs/type.ts
@@ -1,14 +1,37 @@
-// 탭 루트 컴포넌트
-export interface Tabs {}
+/**
+ * 탭 루트 컴포넌트
+ */
+export interface TabsContainerProps {
+  children?: React.ReactNode;
+  defaultTabId: string;
+}
 
-// 탭 버튼 그룹 컴포넌트
-export interface TabGroup {}
+/**
+ * 탭 버튼 그룹 컴포넌트
+ */
+export interface TabGroupProps {
+  children?: React.ReactNode;
+}
 
-// 개별 탭 버튼 컴포넌트
-export interface TabProps {}
+/**
+ * 개별 탭 버튼 컴포넌트
+ */
+export interface TabProps {
+  children?: React.ReactNode;
+  id: string;
+}
 
-// 탭 내용 그룹 컴포넌트
-export interface ContentGroup {}
+/**
+ * 탭 내용 그룹 컴포넌트
+ */
+export interface ContentGroupProps {
+  children?: React.ReactNode;
+}
 
-// 개별 탭 내용 컴포넌트
-export interface ContentProps {}
+/**
+ * 개별 탭 내용 컴포넌트
+ */
+export interface ContentProps {
+  children?: React.ReactNode;
+  id: string;
+}

--- a/src/components/tabs/type.ts
+++ b/src/components/tabs/type.ts
@@ -20,6 +20,7 @@ export type TabProps = LiProps &
   ButtonProps & {
     children?: React.ReactNode;
     id: string;
+    as?: React.ElementType;
   };
 
 export type ContentGroupProps = DivProps & {
@@ -32,13 +33,13 @@ export type ContentProps = DivProps & {
 };
 
 export type TabsContextType = {
-  activeTab: string;
+  activeTab: string | undefined;
   handleChange: (newTab: string) => void;
 };
 
 export type TabsProviderProps = {
   children?: React.ReactNode;
-  defaultTab?: string;
+  defaultTab?: string | undefined;
   tab?: string;
   onChange?: (newTab: string) => void;
 };

--- a/src/components/tabs/type.ts
+++ b/src/components/tabs/type.ts
@@ -1,34 +1,44 @@
-import { Dispatch, SetStateAction } from 'react';
+import { ReactElement } from 'react';
+
+type DivProps = React.HTMLAttributes<HTMLDivElement>;
+type ButtonProps = React.HTMLAttributes<HTMLButtonElement>;
+type UlProps = React.HTMLAttributes<HTMLUListElement>;
+type LiProps = React.HTMLAttributes<HTMLLIElement>;
 
 export type TabsComponentProps = {
-  children?: React.ReactNode;
-  defaultTab: string;
+  children: [ReactElement<TabGroupProps>, ReactElement<ContentGroupProps>];
+  defaultTab?: string;
+  tab?: string;
+  onChange?: (newTab: string) => void;
 };
 
-export type TabGroupProps = {
-  children?: React.ReactNode;
+export type TabGroupProps = UlProps & {
+  children: ReactElement<TabProps> | ReactElement<TabProps>[];
 };
 
-export type TabProps = {
-  children?: React.ReactNode;
-  id: string;
+export type TabProps = LiProps &
+  ButtonProps & {
+    children?: React.ReactNode;
+    id: string;
+  };
+
+export type ContentGroupProps = DivProps & {
+  children: ReactElement<ContentProps> | ReactElement<ContentProps>[];
 };
 
-export type ContentGroupProps = {
-  children?: React.ReactNode;
-};
-
-export type ContentProps = {
+export type ContentProps = DivProps & {
   children?: React.ReactNode;
   id: string;
 };
 
 export type TabsContextType = {
   activeTab: string;
-  setActiveTab: Dispatch<SetStateAction<string>>;
+  handleChange: (newTab: string) => void;
 };
 
 export type TabsProviderProps = {
   children?: React.ReactNode;
-  defaultTab: string;
+  defaultTab?: string;
+  tab?: string;
+  onChange?: (newTab: string) => void;
 };

--- a/src/components/tabs/type.ts
+++ b/src/components/tabs/type.ts
@@ -1,37 +1,34 @@
-/**
- * 탭 루트 컴포넌트
- */
-export interface TabsContainerProps {
-  children?: React.ReactNode;
-  defaultTabId: string;
-}
+import { Dispatch, SetStateAction } from 'react';
 
-/**
- * 탭 버튼 그룹 컴포넌트
- */
-export interface TabGroupProps {
+export type TabsComponentProps = {
   children?: React.ReactNode;
-}
+  defaultTab: string;
+};
 
-/**
- * 개별 탭 버튼 컴포넌트
- */
-export interface TabProps {
+export type TabGroupProps = {
+  children?: React.ReactNode;
+};
+
+export type TabProps = {
   children?: React.ReactNode;
   id: string;
-}
+};
 
-/**
- * 탭 내용 그룹 컴포넌트
- */
-export interface ContentGroupProps {
+export type ContentGroupProps = {
   children?: React.ReactNode;
-}
+};
 
-/**
- * 개별 탭 내용 컴포넌트
- */
-export interface ContentProps {
+export type ContentProps = {
   children?: React.ReactNode;
   id: string;
-}
+};
+
+export type TabsContextType = {
+  activeTab: string;
+  setActiveTab: Dispatch<SetStateAction<string>>;
+};
+
+export type TabsProviderProps = {
+  children?: React.ReactNode;
+  defaultTab: string;
+};

--- a/src/components/tabs/type.ts
+++ b/src/components/tabs/type.ts
@@ -3,7 +3,6 @@ import { ReactElement } from 'react';
 type DivProps = React.HTMLAttributes<HTMLDivElement>;
 type ButtonProps = React.HTMLAttributes<HTMLButtonElement>;
 type UlProps = React.HTMLAttributes<HTMLUListElement>;
-type LiProps = React.HTMLAttributes<HTMLLIElement>;
 
 export type TabsComponentProps = {
   children: [ReactElement<TabGroupProps>, ReactElement<ContentGroupProps>];
@@ -16,19 +15,16 @@ export type TabGroupProps = UlProps & {
   children: ReactElement<TabProps> | ReactElement<TabProps>[];
 };
 
-export type TabProps = LiProps &
-  ButtonProps & {
-    children?: React.ReactNode;
-    id: string;
-    as?: React.ElementType;
-  };
+export type TabProps<T extends keyof HTMLElementTagNameMap = 'button'> = ButtonProps & {
+  id: string;
+  as?: T;
+} & React.HTMLAttributes<HTMLElementTagNameMap[T]>;
 
 export type ContentGroupProps = DivProps & {
   children: ReactElement<ContentProps> | ReactElement<ContentProps>[];
 };
 
 export type ContentProps = DivProps & {
-  children?: React.ReactNode;
   id: string;
 };
 

--- a/src/components/tabs/type.ts
+++ b/src/components/tabs/type.ts
@@ -1,0 +1,14 @@
+// 탭 루트 컴포넌트
+export interface Tabs {}
+
+// 탭 버튼 그룹 컴포넌트
+export interface TabGroup {}
+
+// 개별 탭 버튼 컴포넌트
+export interface TabProps {}
+
+// 탭 내용 그룹 컴포넌트
+export interface ContentGroup {}
+
+// 개별 탭 내용 컴포넌트
+export interface ContentProps {}

--- a/src/components/tabs/utils.ts
+++ b/src/components/tabs/utils.ts
@@ -1,0 +1,23 @@
+import { Children, isValidElement, ReactElement } from 'react';
+import TabGroup from './subcomponents/tab-group';
+import Tab from './subcomponents/tab';
+import { TabGroupProps, TabProps } from './type';
+
+export const findFirstTabId = (children: React.ReactNode): string | undefined => {
+  const childrenArray = Children.toArray(children);
+
+  const tabGroup = childrenArray.find(
+    (child): child is ReactElement<TabGroupProps> => isValidElement(child) && child.type === TabGroup
+  );
+
+  if (!tabGroup || !isValidElement(tabGroup)) return undefined;
+
+  const tabListChildren = Children.toArray(tabGroup.props.children);
+  const firstTab = tabListChildren.find(
+    (child): child is ReactElement<TabProps> => isValidElement(child) && (child.type as any) === Tab
+  );
+
+  if (!firstTab || !isValidElement(firstTab)) return undefined;
+
+  return firstTab.props.id;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #13 

<br>

## 📝 작업 내용

- Tabs와 서브 컴포넌트를 추가했습니다.
  - `TabGroup`, `Tab`, `ContentGroup`, `Content`
  - 컴포넌트의 각 타입을 정의했습니다.
- 제어 모드와 비제어 모드를 나누었습니다.
  - 비제어 모드일 경우 각 탭을 클릭하면 해당 탭과 같은 id를 가진 탭이 보입니다.
  - 제어 모드일 경우 사용자가 직접 `onChange` 함수에 `activeTab`을 set하는 함수를 넣어야 합니다.

```tsx
<Tabs defaultTab="1">
  <Tabs.tabGroup>
    <Tabs.tab id="1">1번 탭</Tabs.tab>
    <Tabs.tab id="2">2번 탭</Tabs.tab>
    <Tabs.tab id="3">3번 탭</Tabs.tab>
  </Tabs.tabGroup>
  <Tabs.contentGroup>
    <Tabs.content id="1">1번 탭의 내용</Tabs.content>
    <Tabs.content id="2">2번 탭의 내용</Tabs.content>
    <Tabs.content id="3">3번 탭의 내용</Tabs.content>
  </Tabs.contentGroup>
</Tabs>
```
비제어 모드일 경우 `defaultTab`, 제어 모드일 경우 `tab`에 디폴트 탭 id를 넣어주어야 합니다.

<br>

## 🖼 스크린샷

### 비제어 모드

https://github.com/user-attachments/assets/4e779125-5278-40f6-9b6a-d19cb363436b

### 제어 모드

https://github.com/user-attachments/assets/1dd002eb-1814-4d54-b200-bbf3b0cd0d05
