### PR TITLE
Feature/#10 dropdown

### DIFF
--- a/src/components/dropdown/context.tsx
+++ b/src/components/dropdown/context.tsx
@@ -1,8 +1,10 @@
-import { createContext, useState } from 'react';
+import { createContext, useId, useState } from 'react';
 import { DropdownProps, DropdownContextType } from './type';
 
 export const dropdownContext = createContext<DropdownContextType>({
   isOpen: false,
+  triggerId: '',
+  menuId: '',
   openMenu() {},
   closeMenu() {},
   toggleMenu() {}
@@ -13,6 +15,9 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
 
   const isControlled = open !== undefined;
   const isOpen = isControlled ? open : internalOpen;
+
+  const triggerId = useId();
+  const menuId = useId();
 
   if (isControlled && !onOpenChange)
     console.warn(
@@ -31,7 +36,9 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
   const toggleMenu = () => setOpen(!isOpen);
 
   return (
-    <dropdownContext.Provider value={{ isOpen, openMenu, closeMenu, toggleMenu }}>{children}</dropdownContext.Provider>
+    <dropdownContext.Provider value={{ isOpen, triggerId, menuId, openMenu, closeMenu, toggleMenu }}>
+      {children}
+    </dropdownContext.Provider>
   );
 };
 export default DropdownProvider;

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -1,5 +1,6 @@
 import DropdownProvider from './context';
 import { DropdownProps } from './type';
+import './style.css';
 
 const DropdownComponent = ({ children, ...props }: DropdownProps) => {
   return <DropdownProvider {...props}>{children}</DropdownProvider>;

--- a/src/components/dropdown/hook.ts
+++ b/src/components/dropdown/hook.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { dropdownContext } from './context';
+
+export const useDropdownContext = () => {
+  const context = useContext(dropdownContext);
+  if (!context) {
+    throw new Error('useDropdown must be used within a dropdownContext');
+  }
+  return context;
+};

--- a/src/components/dropdown/style.css
+++ b/src/components/dropdown/style.css
@@ -1,0 +1,23 @@
+.dropdown-content {
+  min-width: 11.25rem;
+  background-color: white;
+  margin-top: 0.5rem;
+  border-radius: 6px;
+  padding: 0.25rem;
+  box-shadow: 0px 10px 38px -10px rgba(22, 23, 24, 0.35), 0px 10px 20px -15px rgba(22, 23, 24, 0.2);
+  animation-duration: 300ms;
+  animation-timing-function: ease-in-out;
+  animation-name: slideDownAndFade;
+  will-change: transform, opacity;
+}
+
+@keyframes slideDownAndFade {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/components/dropdown/subcomponents/dropdown-content.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-content.tsx
@@ -1,14 +1,21 @@
 import { useContext, forwardRef } from 'react';
+import { createPortal } from 'react-dom';
 import { dropdownContext } from '../context';
 import { DropdownContentProps } from '../type';
-import { createPortal } from 'react-dom';
 
 const DropdownContent = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, className, ...props }, ref) => {
-  const { isOpen } = useContext(dropdownContext);
+  const { isOpen, triggerId, menuId } = useContext(dropdownContext);
 
   if (!isOpen) return null;
   return createPortal(
-    <div ref={ref} className={`dropdown-content ${className}`} {...props}>
+    <div
+      role="menu"
+      id={menuId}
+      ref={ref}
+      className={`dropdown-content ${className}`}
+      aria-labelledby={triggerId}
+      {...props}
+    >
       {children}
     </div>,
     document.body

--- a/src/components/dropdown/subcomponents/dropdown-content.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-content.tsx
@@ -1,14 +1,17 @@
 import { useContext, forwardRef } from 'react';
 import { dropdownContext } from '../context';
 import { DropdownContentProps } from '../type';
+import { createPortal } from 'react-dom';
 
-const DropdownContent = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, style, ...props }, ref) => {
+const DropdownContent = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, className, ...props }, ref) => {
   const { isOpen } = useContext(dropdownContext);
 
-  return (
-    <div ref={ref} {...props} style={{ display: isOpen ? 'block' : 'none', ...style }}>
+  if (!isOpen) return null;
+  return createPortal(
+    <div ref={ref} className={`dropdown-content ${className}`} {...props}>
       {children}
-    </div>
+    </div>,
+    document.body
   );
 });
 

--- a/src/components/dropdown/subcomponents/dropdown-content.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-content.tsx
@@ -1,10 +1,10 @@
-import { useContext, forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { createPortal } from 'react-dom';
-import { dropdownContext } from '../context';
+import { useDropdownContext } from '../hook';
 import { DropdownContentProps } from '../type';
 
 const DropdownContent = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, className, ...props }, ref) => {
-  const { isOpen, triggerId, menuId } = useContext(dropdownContext);
+  const { isOpen, triggerId, menuId } = useDropdownContext();
 
   if (!isOpen) return null;
   return createPortal(

--- a/src/components/dropdown/subcomponents/dropdown-group.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-group.tsx
@@ -1,13 +1,20 @@
-import { forwardRef } from 'react';
-import { DropdownGroupProps } from '../type';
+import { ElementType, forwardRef, Ref } from 'react';
+import { DropdownGroupProps, ListType } from '../type';
 
-const DropdownGroup = forwardRef<HTMLUListElement, DropdownGroupProps>(({ children, ...props }, ref) => {
+const DropdownGroupInner = <T extends ListType = 'ul'>(
+  { children, as = 'ul' as T, ...props }: DropdownGroupProps<T>,
+  ref: Ref<HTMLElementTagNameMap[T]>
+) => {
+  const Component = as as ElementType;
+
   return (
-    <ul role="group" ref={ref} {...props}>
+    <Component role="group" ref={ref} {...props}>
       {children}
-    </ul>
+    </Component>
   );
-});
-DropdownGroup.displayName = 'dropdown-group';
+};
+
+const DropdownGroup = forwardRef(DropdownGroupInner);
+DropdownGroup.displayName = 'DropdownGroup';
 
 export default DropdownGroup;

--- a/src/components/dropdown/subcomponents/dropdown-group.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-group.tsx
@@ -1,10 +1,9 @@
 import { forwardRef } from 'react';
-
-type DropdownGroupProps = React.HtmlHTMLAttributes<HTMLUListElement> & {};
+import { DropdownGroupProps } from '../type';
 
 const DropdownGroup = forwardRef<HTMLUListElement, DropdownGroupProps>(({ children, ...props }, ref) => {
   return (
-    <ul ref={ref} {...props}>
+    <ul role="group" ref={ref} {...props}>
       {children}
     </ul>
   );

--- a/src/components/dropdown/subcomponents/dropdown-item.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-item.tsx
@@ -13,7 +13,7 @@ const DropdownItem = forwardRef<HTMLLIElement, DropdownItemProps>(({ children, o
   };
 
   return (
-    <li onClick={handleDropdownItemClick} ref={ref} {...props}>
+    <li role="menuitem" ref={ref} onClick={handleDropdownItemClick} {...props}>
       {children}
     </li>
   );

--- a/src/components/dropdown/subcomponents/dropdown-item.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-item.tsx
@@ -1,11 +1,15 @@
-import { forwardRef } from 'react';
+import { ElementType, forwardRef, Ref } from 'react';
 import { useDropdownContext } from '../hook';
-import { DropdownItemProps } from '../type';
+import { DropdownItemProps, ItemType } from '../type';
 
-const DropdownItem = forwardRef<HTMLLIElement, DropdownItemProps>(({ children, onClick, ...props }, ref) => {
+const DropdownItemInner = <T extends ItemType>(
+  { children, as = 'li' as T, onClick, ...props }: DropdownItemProps<T>,
+  ref: Ref<HTMLElementTagNameMap[T]>
+) => {
+  const Component = as as ElementType;
   const { closeMenu } = useDropdownContext();
 
-  const handleDropdownItemClick = (e: React.MouseEvent<HTMLLIElement>) => {
+  const handleDropdownItemClick = (e: React.MouseEvent<HTMLElementTagNameMap[T]>) => {
     if (!!onClick && typeof onClick !== 'function')
       console.warn('onClick should be a function, ignoring invalid handler');
     else if (!!onClick) onClick(e);
@@ -13,11 +17,13 @@ const DropdownItem = forwardRef<HTMLLIElement, DropdownItemProps>(({ children, o
   };
 
   return (
-    <li role="menuitem" ref={ref} onClick={handleDropdownItemClick} {...props}>
+    <Component role="menuitem" ref={ref} onClick={handleDropdownItemClick} {...props}>
       {children}
-    </li>
+    </Component>
   );
-});
+};
+
+const DropdownItem = forwardRef(DropdownItemInner);
 DropdownItem.displayName = 'dropdown-item';
 
 export default DropdownItem;

--- a/src/components/dropdown/subcomponents/dropdown-item.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-item.tsx
@@ -1,9 +1,9 @@
-import { forwardRef, useContext } from 'react';
-import { dropdownContext } from '../context';
+import { forwardRef } from 'react';
+import { useDropdownContext } from '../hook';
 import { DropdownItemProps } from '../type';
 
 const DropdownItem = forwardRef<HTMLLIElement, DropdownItemProps>(({ children, onClick, ...props }, ref) => {
-  const { closeMenu } = useContext(dropdownContext);
+  const { closeMenu } = useDropdownContext();
 
   const handleDropdownItemClick = (e: React.MouseEvent<HTMLLIElement>) => {
     if (!!onClick && typeof onClick !== 'function')

--- a/src/components/dropdown/subcomponents/dropdown-separator.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-separator.tsx
@@ -2,7 +2,7 @@ import { forwardRef } from 'react';
 import { DropdownSeparatorProps } from '../type';
 
 const DropdownSeparator = forwardRef<HTMLHRElement, DropdownSeparatorProps>((props, ref) => {
-  return <hr ref={ref} {...props} />;
+  return <hr ref={ref} role="separator" aria-orientation="horizontal" {...props} />;
 });
 DropdownSeparator.displayName = 'dropdown-separator';
 

--- a/src/components/dropdown/subcomponents/dropdown-trigger.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-trigger.tsx
@@ -3,17 +3,25 @@ import { dropdownContext } from '../context';
 import { DropdownTriggerProps } from '../type';
 
 const DropdownTrigger = forwardRef<HTMLButtonElement, DropdownTriggerProps>(({ children, onClick, ...props }, ref) => {
-  const { toggleMenu } = useContext(dropdownContext);
+  const { isOpen, openMenu, triggerId, menuId } = useContext(dropdownContext);
 
   const handleTriggerClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (!!onClick && typeof onClick !== 'function')
       console.warn('onClick should be a function, ignoring invalid handler');
     else if (!!onClick) onClick(e);
-    toggleMenu();
+    openMenu();
   };
 
   return (
-    <button onClick={handleTriggerClick} ref={ref} {...props}>
+    <button
+      id={triggerId}
+      ref={ref}
+      onClick={handleTriggerClick}
+      aria-haspopup="menu"
+      aria-expanded={isOpen}
+      {...(isOpen ? { 'aria-controls': menuId } : {})}
+      {...props}
+    >
       {children}
     </button>
   );

--- a/src/components/dropdown/subcomponents/dropdown-trigger.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-trigger.tsx
@@ -1,9 +1,9 @@
-import { forwardRef, useContext } from 'react';
-import { dropdownContext } from '../context';
+import { forwardRef } from 'react';
+import { useDropdownContext } from '../hook';
 import { DropdownTriggerProps } from '../type';
 
 const DropdownTrigger = forwardRef<HTMLButtonElement, DropdownTriggerProps>(({ children, onClick, ...props }, ref) => {
-  const { isOpen, openMenu, triggerId, menuId } = useContext(dropdownContext);
+  const { isOpen, openMenu, triggerId, menuId } = useDropdownContext();
 
   const handleTriggerClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (!!onClick && typeof onClick !== 'function')

--- a/src/components/dropdown/type.ts
+++ b/src/components/dropdown/type.ts
@@ -1,14 +1,23 @@
 import { ReactNode } from 'react';
 
+export type ItemType = 'li' | 'button' | 'a' | 'div';
+export type ListType = 'ul' | 'ol' | 'div';
+
 type DivProps = React.HTMLAttributes<HTMLDivElement>;
-type UlProps = React.HTMLAttributes<HTMLUListElement>;
-type LiProps = React.HTMLAttributes<HTMLLIElement>;
 type ButtonProps = React.HTMLAttributes<HTMLButtonElement>;
 type HrProps = React.HTMLAttributes<HTMLHRElement>;
 
 export type DropdownContentProps = DivProps & {};
-export type DropdownGroupProps = UlProps & {};
-export type DropdownItemProps = LiProps & {};
+export type DropdownGroupProps<T extends ListType & keyof HTMLElementTagNameMap = 'ul'> = React.HTMLAttributes<
+  HTMLElementTagNameMap[T]
+> & {
+  as?: T;
+};
+export type DropdownItemProps<T extends ItemType & keyof HTMLElementTagNameMap = 'li'> = React.HTMLAttributes<
+  HTMLElementTagNameMap[T]
+> & {
+  as?: T;
+};
 export type DropdownTriggerProps = ButtonProps & {};
 export type DropdownSeparatorProps = HrProps & {};
 

--- a/src/components/dropdown/type.ts
+++ b/src/components/dropdown/type.ts
@@ -14,6 +14,8 @@ export type DropdownSeparatorProps = HrProps & {};
 
 export type DropdownContextType = {
   isOpen: boolean;
+  triggerId: string;
+  menuId: string;
   openMenu: () => void;
   closeMenu: () => void;
   toggleMenu: () => void;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #10

<br>

## 📝 작업 내용

- `portal`을 통해, document.body 밑에 menu 탭을 렌더링 시켜 z-index 및 absolute, overflow와 같은 css 제한에서 벗어남.
- 열릴 때의 animation 추가 (닫힐 때는 animation을 추가하지 않았습니다!)
- 하위 컴포넌트 들에 적절한 role 설정
- group 및 item 컴포넌트에 as 속성을 통해 사용자가 원하는 tag로 변경할 수 있도록 수정

<br>

## 🖼 스크린샷

![image](https://github.com/user-attachments/assets/52687401-064f-454a-9ce9-858e9e154b48)

<br>

## 💬 리뷰 요구사항
- 리뷰 예상 시간 : `10분`
- 코드 구조
```tsx
      <Dropdown onOpenChange={handleModalOpenChange}>
        <Dropdown.trigger>click me!</Dropdown.trigger>
        <Dropdown.content>
          <Dropdown.group as="ol" ref={ref}>
            <Dropdown.item>item 1</Dropdown.item>
            <Dropdown.item>item 2</Dropdown.item>
          </Dropdown.group>
          <Dropdown.group as="ul" ref={ref}>
            <Dropdown.item>item 1</Dropdown.item>
            <Dropdown.item>item 2</Dropdown.item>
          </Dropdown.group>
          <Dropdown.group as="div" ref={ref}>
            <Dropdown.item as="button">item 1</Dropdown.item>
            <Dropdown.item as="a">item 2</Dropdown.item>
            <Dropdown.item as="div">item 2</Dropdown.item>
          </Dropdown.group>
        </Dropdown.content>
      </Dropdown>
```

- 아직 CSS를 다루지 않았습니다.
- 내일 중으로 메뉴의 위치를 screen 내 적절한 내에 위치시키는 기능을 구현하겠습니다.
- 그리고 지윤님의 코드가 머지되면 esc 및 메뉴 바깥 클릭 시 닫히는 기능 & tab으로 이동을 적용하겠습니다!