### PR TITLE
Bug fix/#25 breadcrumb custom hook fix

### DIFF
--- a/src/components/breadcrumb/breadcrumb.stories.tsx
+++ b/src/components/breadcrumb/breadcrumb.stories.tsx
@@ -79,9 +79,9 @@ export const CustomSeparator = CustomSeparatorTemplate.bind({});
 const CollapseTemplate: StoryFn = () => (
   <Breadcrumb>
     <Breadcrumb.list
-      maxItems={3}
-      itemsBeforeCollapse={1}
-      itemsAfterCollapse={2}
+      maxItems={7}
+      // itemsBeforeCollapse={1}
+      // itemsAfterCollapse={5}
       // ellipsisStyle={<span onClick={() => alert('Expand Breadcrumbs!')}>🔍 More...</span>}
     >
       <Breadcrumb.item>
@@ -105,7 +105,11 @@ const CollapseTemplate: StoryFn = () => (
       </Breadcrumb.item>
       <Breadcrumb.separator />
       <Breadcrumb.item>
-        <Breadcrumb.page>Item 6</Breadcrumb.page>
+        <Breadcrumb.link href="/">Item 6</Breadcrumb.link>
+      </Breadcrumb.item>
+      <Breadcrumb.separator />
+      <Breadcrumb.item>
+        <Breadcrumb.page>Item 7</Breadcrumb.page>
       </Breadcrumb.item>
     </Breadcrumb.list>
   </Breadcrumb>

--- a/src/components/breadcrumb/breadcrumb.stories.tsx
+++ b/src/components/breadcrumb/breadcrumb.stories.tsx
@@ -80,9 +80,9 @@ const CollapseTemplate: StoryFn = () => (
   <Breadcrumb>
     <Breadcrumb.list
       maxItems={6}
-      // itemsBeforeCollapse={2}
-      // itemsAfterCollapse={3}
-      // ellipsisStyle={<span onClick={() => alert('Expand Breadcrumbs!')}>🔍 More...</span>}
+      itemsBeforeCollapse={4}
+      itemsAfterCollapse={4}
+      ellipsisStyle={<span onClick={() => alert('Expand Breadcrumbs!')}>🔍 More...</span>}
     >
       <Breadcrumb.item>
         <Breadcrumb.link href="/">Item 1</Breadcrumb.link>

--- a/src/components/breadcrumb/breadcrumb.stories.tsx
+++ b/src/components/breadcrumb/breadcrumb.stories.tsx
@@ -80,8 +80,8 @@ const CollapseTemplate: StoryFn = () => (
   <Breadcrumb>
     <Breadcrumb.list
       maxItems={6}
-      itemsBeforeCollapse={3}
-      itemsAfterCollapse={6}
+      // itemsBeforeCollapse={2}
+      // itemsAfterCollapse={3}
       // ellipsisStyle={<span onClick={() => alert('Expand Breadcrumbs!')}>🔍 More...</span>}
     >
       <Breadcrumb.item>

--- a/src/components/breadcrumb/breadcrumb.stories.tsx
+++ b/src/components/breadcrumb/breadcrumb.stories.tsx
@@ -79,9 +79,9 @@ export const CustomSeparator = CustomSeparatorTemplate.bind({});
 const CollapseTemplate: StoryFn = () => (
   <Breadcrumb>
     <Breadcrumb.list
-      maxItems={7}
-      // itemsBeforeCollapse={1}
-      // itemsAfterCollapse={5}
+      maxItems={6}
+      itemsBeforeCollapse={3}
+      itemsAfterCollapse={6}
       // ellipsisStyle={<span onClick={() => alert('Expand Breadcrumbs!')}>🔍 More...</span>}
     >
       <Breadcrumb.item>

--- a/src/components/breadcrumb/hook.tsx
+++ b/src/components/breadcrumb/hook.tsx
@@ -27,7 +27,7 @@ export const useBreadcrumbCollapse = ({
     const beforeIndex = validBeforeCollapse ? children.findIndex((child) => child === items[itemsBeforeCollapse]) : 2;
     const afterIndex = validAfterCollapse
       ? children.findIndex((child) => child === items[items.length - itemsAfterCollapse])
-      : children.length - 3;
+      : children.length - 1;
 
     if (beforeIndex < afterIndex) {
       visibleItems = [

--- a/src/components/breadcrumb/hook.tsx
+++ b/src/components/breadcrumb/hook.tsx
@@ -12,43 +12,30 @@ export const useBreadcrumbCollapse = ({
 }: UseBreadcrumbCollapseProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  /**NOTE - 타입 가드 함수
-   * child가 ReactElement여야 type 속성에 접근이 가능합니다.
-   * 그래서 '타입 가드 함수(is)'를 이용하여 child를 ReactElement로 먼저 간주하도록 합니다.
-   * child is ReactElement : child가 ReactElement라는 것을 TS가 알도록 타입 가드 적용
-   * React.isValidElement(child) : child가 ReactElement인지 확인
-   * typeof child.type === "function" : child.type이 "div"같은 문자열이 아니라, 함수형 컴포넌트인지 확인
-   * child.type.name === "BreadcrumbItem" 그 중에서 BreadcrumbItem인지 확인
-   */
   const items = children.filter(
     (child): child is ReactElement =>
       React.isValidElement(child) && typeof child.type === 'function' && child.type.name === 'BreadcrumbItem'
   );
 
-  const isCollapse = items.length > maxItems && !isExpanded;
+  const isCollapse = maxItems !== undefined && items.length > maxItems && !isExpanded;
   let visibleItems: ReactNode[] = children;
 
-  /**TODO
-   * maxItems 삭제
-   * itemsBeforeCollapse 또는 itemsAfterCollapse가 props로 내려올 시 축소
-   * 이외의 경우에는 축소 x
-   * 위 변수들에 대한 검증로직 추가
-   * index !== -1 검증 삭제 + items가 빈 배열일 경우 접근시 undefined 나오는 문제 해결
-   */
-  if (isCollapse) {
-    const beforeIndex = children.findIndex((child) => child === items[itemsBeforeCollapse]);
-    const afterIndex = children.findIndex((child) => child === items[items.length - itemsAfterCollapse]);
+  if (isCollapse && items.length > 0) {
+    const validBeforeCollapse = itemsBeforeCollapse >= 0 && itemsBeforeCollapse < items.length;
+    const validAfterCollapse = itemsAfterCollapse >= 0 && itemsAfterCollapse < items.length;
 
-    const before = beforeIndex !== -1 ? beforeIndex : itemsBeforeCollapse;
-    const after = afterIndex !== -1 ? afterIndex : items.length - itemsAfterCollapse;
+    const beforeIndex = validBeforeCollapse ? children.findIndex((child) => child === items[itemsBeforeCollapse]) : 1;
+    const afterIndex = validAfterCollapse
+      ? children.findIndex((child) => child === items[items.length - itemsAfterCollapse])
+      : items.length;
 
-    if (before < after) {
+    if (beforeIndex < afterIndex) {
       visibleItems = [
-        ...children.slice(0, before),
+        ...children.slice(0, beforeIndex),
         <BreadcrumbEllipsis onClick={() => setIsExpanded(true)}>
           {ellipsisStyle ?? <Ellipsis size={16} />}
         </BreadcrumbEllipsis>,
-        ...children.slice(after - 1)
+        ...children.slice(afterIndex - 1)
       ];
     }
   }

--- a/src/components/breadcrumb/hook.tsx
+++ b/src/components/breadcrumb/hook.tsx
@@ -24,10 +24,10 @@ export const useBreadcrumbCollapse = ({
     const validBeforeCollapse = itemsBeforeCollapse >= 0 && itemsBeforeCollapse < items.length;
     const validAfterCollapse = itemsAfterCollapse >= 0 && itemsAfterCollapse < items.length;
 
-    const beforeIndex = validBeforeCollapse ? children.findIndex((child) => child === items[itemsBeforeCollapse]) : 1;
+    const beforeIndex = validBeforeCollapse ? children.findIndex((child) => child === items[itemsBeforeCollapse]) : 2;
     const afterIndex = validAfterCollapse
       ? children.findIndex((child) => child === items[items.length - itemsAfterCollapse])
-      : items.length;
+      : children.length - 3;
 
     if (beforeIndex < afterIndex) {
       visibleItems = [

--- a/src/components/breadcrumb/hook.tsx
+++ b/src/components/breadcrumb/hook.tsx
@@ -1,7 +1,11 @@
-import React, { ReactElement, ReactNode, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import BreadcrumbEllipsis from './subcomponents/breadcrumb-ellipsis';
 import { Ellipsis } from 'lucide-react';
 import UseBreadcrumbCollapseProps from './type';
+
+const DEFAULT_BEFORE = 2
+const DEFAULT_AFTER = 1
+const ELLIPSIS_SIZE = 16
 
 export const useBreadcrumbCollapse = ({
   children,
@@ -12,30 +16,31 @@ export const useBreadcrumbCollapse = ({
 }: UseBreadcrumbCollapseProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const items = children.filter(
+  const childrenArray = React.Children.toArray(children) as ReactElement[];
+  const items = childrenArray.filter(
     (child): child is ReactElement =>
       React.isValidElement(child) && typeof child.type === 'function' && child.type.name === 'BreadcrumbItem'
   );
 
   const isCollapse = maxItems !== undefined && items.length > maxItems && !isExpanded;
-  let visibleItems: ReactNode[] = children;
+  let visibleItems: ReactElement[] = childrenArray;
 
   if (isCollapse && items.length > 0) {
-    const validBeforeCollapse = itemsBeforeCollapse >= 0 && itemsBeforeCollapse < items.length;
-    const validAfterCollapse = itemsAfterCollapse >= 0 && itemsAfterCollapse < items.length;
+    const validBeforeCollapse = 0 <= itemsBeforeCollapse && itemsBeforeCollapse < items.length
+    const validAfterCollapse = 0 <= itemsAfterCollapse && itemsAfterCollapse < items.length;
 
-    const beforeIndex = validBeforeCollapse ? children.findIndex((child) => child === items[itemsBeforeCollapse]) : 2;
+    const beforeIndex = validBeforeCollapse ? childrenArray.findIndex((child) => child === items[itemsBeforeCollapse]) : DEFAULT_BEFORE;
     const afterIndex = validAfterCollapse
-      ? children.findIndex((child) => child === items[items.length - itemsAfterCollapse])
-      : children.length - 1;
+      ? childrenArray.findIndex((child) => child === items[items.length - itemsAfterCollapse])
+      : childrenArray.length - DEFAULT_AFTER;
 
     if (beforeIndex < afterIndex) {
       visibleItems = [
-        ...children.slice(0, beforeIndex),
+        ...childrenArray.slice(0, beforeIndex),
         <BreadcrumbEllipsis onClick={() => setIsExpanded(true)}>
-          {ellipsisStyle ?? <Ellipsis size={16} />}
+          {ellipsisStyle ?? <Ellipsis size={ELLIPSIS_SIZE} />}
         </BreadcrumbEllipsis>,
-        ...children.slice(afterIndex - 1)
+        ...childrenArray.slice(afterIndex - 1)
       ];
     }
   }

--- a/src/components/breadcrumb/subcomponents/breadcrumb-list.tsx
+++ b/src/components/breadcrumb/subcomponents/breadcrumb-list.tsx
@@ -14,7 +14,7 @@ const BreadcrumbList = ({
   children,
   className,
   direction = 'row',
-  maxItems = 4,
+  maxItems,
   itemsBeforeCollapse = 1,
   itemsAfterCollapse = 2,
   ellipsisStyle,

--- a/src/components/breadcrumb/type.ts
+++ b/src/components/breadcrumb/type.ts
@@ -2,7 +2,7 @@ import { ReactElement, ReactNode } from 'react';
 
 type UseBreadcrumbCollapseProps = {
   children: ReactNode[];
-  maxItems: number;
+  maxItems?: number;
   itemsBeforeCollapse: number;
   itemsAfterCollapse: number;
   ellipsisStyle?: ReactElement | string;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

-  [[BugFix] Breadcrumb custom hook 수정 #25](https://github.com/zenuix/Zen-UI/issues/25)

<br>

## 📝 작업 내용

- maxItems, itemsAfterCollapse, itemsBeforeCollapse 에 대한 검증 로직 추가
- maxItems를 활용할 방법


<br>

## 💬 리뷰 요구사항

### **maxItems를 활용하는 방안에 대하여**  

[[이전 PR](https://github.com/zenuix/Zen-UI/pull/21)](https://github.com/zenuix/Zen-UI/pull/21)에서 다은님이 `maxItems`를 없애고 `itemsAfterCollapse`와 `itemsBeforeCollapse`를 활용하는 방안을 제안하셨습니다. 해당 방식이 더 직관적일 수 있다고 생각하여, `maxItems` 없이도 축소가 가능하도록 변경을 시도했습니다.  

그러나 실제로 적용해 보니, `maxItems`를 제외하면 사용자가 사용하기 어려운 몇 가지 문제가 발생할 가능성이 있었습니다.  

### **maxItems 없이 축소할 때의 문제점**  
1. `itemsAfterCollapse`만 설정한 경우, 현재 위치를 파악할 수 없는 문제가 발생합니다. 즉, 축소되었을 때 현재 내가 어디쯤 있는지 알기 어려워지기 때문에 `itemsBeforeCollapse`를 반드시 함께 사용해야 합니다. 하지만 `itemsBeforeCollapse`라는 이름만으로는 "축소를 위해 꼭 설정해야 하는 값"이라는 점이 직관적으로 전달되지 않아 사용성이 떨어질 수 있습니다.  

2. 이를 해결하기 위해 `"useCollapse"` 같은 새로운 props를 추가하는 방법도 고려할 수 있습니다. 하지만 결국 이것은 `maxItems`를 기능적으로 없앤 것일 뿐, 같은 역할을 하는 props를 다르게 부르는 것에 지나지 않습니다.  

3. `maxItems`와 `itemsAfterCollapse`, `itemsBeforeCollapse`를 함께 사용할 경우, 의도한 값의 의미가 비틀릴 가능성이 있습니다. 예를 들어, 항목이 총 8개인데 `maxItems = 5`, `itemsBeforeCollapse = 3`, `itemsAfterCollapse = 3`이라면 로직상 모순이 발생할 수 있습니다. 그러나 `maxItems`가 없는 경우에도 유사한 문제가 발생할 수 있습니다. 예를 들어, 음수를 설정하거나, 앞뒤 항목 개수를 전체 개수보다 크게 설정하는 등의 잘못된 사용이 가능하기 때문입니다.  

---

### **다시 `maxItems`로 돌아간 이유**  
이전 PR에서는 항목이 많아지면 자동으로 축소되도록 만들었습니다. 하지만 자동 축소가 이루어질 경우, 사용자가 이를 커스터마이징하려 할 때 오히려 제한적인 경험이 될 수도 있습니다.  

반대로 `maxItems` 없이 설계하면, 사용자가 별도로 설정하지 않는 한 리스트는 축소되지 않습니다. 하지만 이 경우, 항목을 줄이려는 사용자가 적절한 설정을 찾기가 어려울 수 있습니다.  

이에 따라 기본적으로는 모든 항목을 보여주되, 사용자가 원할 경우 `maxItems`를 설정하여 간편하게 축소할 수 있도록 하는 것이 더 나은 UX라고 판단했습니다.
또한 `maxItems`에 대한 검증을 강화하고 기존의 `itemsBeforeCollapse`와 `itemsAfterCollapse`를 보조적 수단으로 사용한다면 더 직관적인 축소 로직을 제공할 수 있다고 생각합니다.   

그래서 이번 PR에서는 `maxItems`만 사용하더라도 축소가 이루어지도록 했습니다. 디폴트 값은 `itemsBeforeCollapse = 1`, `itemsAfterCollapse = 2` 입니다. 또한 props에 대한 검증을 강화했습니다. 이 props에 유효하지 않은 값이 들어가면 값에 따라 디폴트 축소가 발생하거나 축소가 되지 않습니다. 이런 식으로 코드를 작성하면 사용자의 편의성을 더 제공할 수 있다고 생각합니다. 

글이 너무 장황해졌는데, 다른 의견 있으시면 자유롭게 말씀해주세요!
