### PR TITLE
Feature/#10 dropdown close

### DIFF
--- a/src/components/dropdown/context.tsx
+++ b/src/components/dropdown/context.tsx
@@ -12,7 +12,13 @@ export const dropdownContext = createContext<DropdownContextType>({
   toggleMenu() {}
 });
 
-const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }: DropdownProps) => {
+const DropdownProvider = ({
+  children,
+  triggerRef: externalTriggerRef,
+  defaultOpen = false,
+  open,
+  onOpenChange
+}: DropdownProps) => {
   const [internalOpen, setInternalOpen] = useState(defaultOpen);
 
   const isControlled = open !== undefined;
@@ -21,12 +27,18 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
   const triggerId = useId();
   const menuId = useId();
 
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const internalTriggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = isControlled ? externalTriggerRef ?? null : internalTriggerRef;
 
   if (isControlled && !onOpenChange)
     console.warn(
       'You provided `open` prop without an `onOpenChange` handler. This will render a non-interactive dropdown component.'
+    );
+
+  if (isControlled && !externalTriggerRef)
+    console.warn(
+      'You provided a controlled dropdown without passing a reference to the trigger element. This may cause positioning issues. Please provide a ref to the trigger element for proper positioning.'
     );
 
   const setOpen = (value: boolean) => {

--- a/src/components/dropdown/context.tsx
+++ b/src/components/dropdown/context.tsx
@@ -1,4 +1,5 @@
 import { createContext, useId, useRef, useState } from 'react';
+import { useEscapeKey } from '../../global-hooks';
 import { DropdownProps, DropdownContextType } from './type';
 
 export const dropdownContext = createContext<DropdownContextType>({
@@ -51,6 +52,8 @@ const DropdownProvider = ({
   const openMenu = () => setOpen(true);
   const closeMenu = () => setOpen(false);
   const toggleMenu = () => setOpen(!isOpen);
+
+  useEscapeKey(closeMenu, isOpen);
 
   return (
     <dropdownContext.Provider

--- a/src/components/dropdown/context.tsx
+++ b/src/components/dropdown/context.tsx
@@ -1,10 +1,12 @@
-import { createContext, useId, useState } from 'react';
+import { createContext, useId, useRef, useState } from 'react';
 import { DropdownProps, DropdownContextType } from './type';
 
 export const dropdownContext = createContext<DropdownContextType>({
   isOpen: false,
   triggerId: '',
   menuId: '',
+  triggerRef: null,
+  menuRef: null,
   openMenu() {},
   closeMenu() {},
   toggleMenu() {}
@@ -18,6 +20,9 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
 
   const triggerId = useId();
   const menuId = useId();
+
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   if (isControlled && !onOpenChange)
     console.warn(
@@ -36,7 +41,9 @@ const DropdownProvider = ({ children, defaultOpen = false, open, onOpenChange }:
   const toggleMenu = () => setOpen(!isOpen);
 
   return (
-    <dropdownContext.Provider value={{ isOpen, triggerId, menuId, openMenu, closeMenu, toggleMenu }}>
+    <dropdownContext.Provider
+      value={{ isOpen, triggerId, menuId, triggerRef, menuRef, openMenu, closeMenu, toggleMenu }}
+    >
       {children}
     </dropdownContext.Provider>
   );

--- a/src/components/dropdown/dropdown.stories.tsx
+++ b/src/components/dropdown/dropdown.stories.tsx
@@ -1,0 +1,49 @@
+import { Meta, StoryFn } from '@storybook/react';
+import Dropdown from '.';
+
+export default {
+  title: 'Components/Dropdown',
+  component: Dropdown
+} as Meta;
+
+const DefaultTemplate: StoryFn = () => {
+  return (
+    <Dropdown>
+      <Dropdown.trigger>Trigger Click me</Dropdown.trigger>
+      <Dropdown.content>
+        <Dropdown.group>
+          <Dropdown.item>Item 1</Dropdown.item>
+          <Dropdown.item>Item 2</Dropdown.item>
+          <Dropdown.item>Item 3</Dropdown.item>
+          <Dropdown.separator />
+          <Dropdown.item>Item 4</Dropdown.item>
+        </Dropdown.group>
+      </Dropdown.content>
+    </Dropdown>
+  );
+};
+export const Default = DefaultTemplate.bind({});
+
+const ElementTemplate: StoryFn = () => {
+  return (
+    <Dropdown>
+      <Dropdown.trigger>Trigger Click me</Dropdown.trigger>
+      <Dropdown.content>
+        <Dropdown.group as="ul">
+          <Dropdown.item>Item 1</Dropdown.item>
+          <Dropdown.item>Item 2</Dropdown.item>
+        </Dropdown.group>
+        <Dropdown.group as="ol">
+          <Dropdown.item>Item 1</Dropdown.item>
+          <Dropdown.item>Item 2</Dropdown.item>
+        </Dropdown.group>
+        <Dropdown.group as="div">
+          <Dropdown.item as="a">Item Anchor</Dropdown.item>
+          <Dropdown.item as="div">Item Div</Dropdown.item>
+          <Dropdown.item as="button">Item Button</Dropdown.item>
+        </Dropdown.group>
+      </Dropdown.content>
+    </Dropdown>
+  );
+};
+export const Element = ElementTemplate.bind({});

--- a/src/components/dropdown/style.css
+++ b/src/components/dropdown/style.css
@@ -1,4 +1,5 @@
 .dropdown-content {
+  position: absolute;
   min-width: 11.25rem;
   background-color: white;
   margin-top: 0.5rem;

--- a/src/components/dropdown/subcomponents/dropdown-content.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-content.tsx
@@ -1,13 +1,26 @@
-import { forwardRef, useEffect } from 'react';
+import { forwardRef, useEffect, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useDropdownContext } from '../hook';
 import { DropdownContentProps } from '../type';
+import { useFocusTrap } from '../../../global-hooks';
 
 const DropdownContent = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, className, ...props }, ref) => {
   const { isOpen, triggerId, menuId, triggerRef, menuRef } = useDropdownContext();
 
+  const positionDropdown = () => {
+    if (!triggerRef || !triggerRef.current || !menuRef || !menuRef.current) return;
 
-  if (isOpen) positionDropdown();
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+
+    menuRef.current.style.top = `${triggerRect.bottom + window.scrollY}px`;
+    menuRef.current.style.left = `${triggerRect.left + window.scrollX}px`;
+  };
+
+  useLayoutEffect(() => {
+    if (isOpen) {
+      positionDropdown();
+    }
+  }, [isOpen, positionDropdown]);
 
   useFocusTrap(menuRef as React.RefObject<HTMLDivElement | null>, isOpen);
 

--- a/src/components/dropdown/subcomponents/dropdown-content.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-content.tsx
@@ -2,10 +2,10 @@ import { forwardRef, useEffect, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useDropdownContext } from '../hook';
 import { DropdownContentProps } from '../type';
-import { useFocusTrap } from '../../../global-hooks';
+import { useFocusTrap, useOutsideClick } from '../../../global-hooks';
 
 const DropdownContent = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, className, ...props }, ref) => {
-  const { isOpen, triggerId, menuId, triggerRef, menuRef } = useDropdownContext();
+  const { isOpen, triggerId, menuId, triggerRef, menuRef, closeMenu } = useDropdownContext();
 
   const positionDropdown = () => {
     if (!triggerRef || !triggerRef.current || !menuRef || !menuRef.current) return;
@@ -23,6 +23,12 @@ const DropdownContent = forwardRef<HTMLDivElement, DropdownContentProps>(({ chil
   }, [isOpen, positionDropdown]);
 
   useFocusTrap(menuRef as React.RefObject<HTMLDivElement | null>, isOpen);
+
+  useOutsideClick(menuRef as React.RefObject<HTMLDivElement | null>, (event) => {
+    if (!triggerRef || !menuRef) return;
+    if (triggerRef.current?.contains(event.target as Node) || menuRef.current?.contains(event.target as Node)) return;
+    if (isOpen) closeMenu();
+  });
 
   useEffect(() => {
     if (!menuRef || !ref) return;

--- a/src/components/dropdown/subcomponents/dropdown-content.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-content.tsx
@@ -1,17 +1,28 @@
-import { forwardRef } from 'react';
+import { forwardRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useDropdownContext } from '../hook';
 import { DropdownContentProps } from '../type';
 
 const DropdownContent = forwardRef<HTMLDivElement, DropdownContentProps>(({ children, className, ...props }, ref) => {
-  const { isOpen, triggerId, menuId } = useDropdownContext();
+  const { isOpen, triggerId, menuId, triggerRef, menuRef } = useDropdownContext();
+
+
+  if (isOpen) positionDropdown();
+
+  useFocusTrap(menuRef as React.RefObject<HTMLDivElement | null>, isOpen);
+
+  useEffect(() => {
+    if (!menuRef || !ref) return;
+    if (typeof ref === 'function') ref(menuRef.current);
+    else ref.current = menuRef.current;
+  }, [ref, isOpen]);
 
   if (!isOpen) return null;
   return createPortal(
     <div
       role="menu"
       id={menuId}
-      ref={ref}
+      ref={menuRef}
       className={`dropdown-content ${className}`}
       aria-labelledby={triggerId}
       {...props}

--- a/src/components/dropdown/subcomponents/dropdown-item.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-item.tsx
@@ -17,7 +17,7 @@ const DropdownItemInner = <T extends ItemType>(
   };
 
   return (
-    <Component role="menuitem" ref={ref} onClick={handleDropdownItemClick} {...props}>
+    <Component role="menuitem" tabIndex="1" ref={ref} onClick={handleDropdownItemClick} {...props}>
       {children}
     </Component>
   );

--- a/src/components/dropdown/subcomponents/dropdown-trigger.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-trigger.tsx
@@ -3,13 +3,13 @@ import { useDropdownContext } from '../hook';
 import { DropdownTriggerProps } from '../type';
 
 const DropdownTrigger = forwardRef<HTMLButtonElement, DropdownTriggerProps>(({ children, onClick, ...props }, ref) => {
-  const { isOpen, triggerId, menuId, triggerRef, openMenu } = useDropdownContext();
+  const { isOpen, triggerId, menuId, triggerRef, toggleMenu } = useDropdownContext();
 
   const handleTriggerClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (!!onClick && typeof onClick !== 'function')
       console.warn('onClick should be a function, ignoring invalid handler');
     else if (!!onClick) onClick(e);
-    openMenu();
+    toggleMenu();
   };
 
   useEffect(() => {

--- a/src/components/dropdown/subcomponents/dropdown-trigger.tsx
+++ b/src/components/dropdown/subcomponents/dropdown-trigger.tsx
@@ -1,9 +1,9 @@
-import { forwardRef } from 'react';
+import { forwardRef, useEffect } from 'react';
 import { useDropdownContext } from '../hook';
 import { DropdownTriggerProps } from '../type';
 
 const DropdownTrigger = forwardRef<HTMLButtonElement, DropdownTriggerProps>(({ children, onClick, ...props }, ref) => {
-  const { isOpen, openMenu, triggerId, menuId } = useDropdownContext();
+  const { isOpen, triggerId, menuId, triggerRef, openMenu } = useDropdownContext();
 
   const handleTriggerClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (!!onClick && typeof onClick !== 'function')
@@ -12,10 +12,16 @@ const DropdownTrigger = forwardRef<HTMLButtonElement, DropdownTriggerProps>(({ c
     openMenu();
   };
 
+  useEffect(() => {
+    if (!triggerRef || !ref) return;
+    if (typeof ref === 'function') ref(triggerRef.current);
+    else ref.current = triggerRef.current;
+  }, [ref, isOpen]);
+
   return (
     <button
       id={triggerId}
-      ref={ref}
+      ref={triggerRef}
       onClick={handleTriggerClick}
       aria-haspopup="menu"
       aria-expanded={isOpen}

--- a/src/components/dropdown/type.ts
+++ b/src/components/dropdown/type.ts
@@ -25,6 +25,8 @@ export type DropdownContextType = {
   isOpen: boolean;
   triggerId: string;
   menuId: string;
+  triggerRef: React.RefObject<HTMLButtonElement | null> | null;
+  menuRef: React.RefObject<HTMLDivElement | null> | null;
   openMenu: () => void;
   closeMenu: () => void;
   toggleMenu: () => void;

--- a/src/components/dropdown/type.ts
+++ b/src/components/dropdown/type.ts
@@ -36,5 +36,6 @@ export type DropdownProps = {
   children: ReactNode;
   defaultOpen?: boolean;
   open?: boolean;
+  triggerRef?: React.RefObject<HTMLButtonElement | null>;
   onOpenChange?: (open: boolean) => void;
 };

--- a/src/global-hooks.ts
+++ b/src/global-hooks.ts
@@ -30,10 +30,11 @@ export const useEscapeKey = (onClose?: () => void, enabled: boolean = true) => {
  */
 export const useFocusTrap = (elementRef: React.RefObject<HTMLElement | null>, isOpen: boolean) => {
   useEffect(() => {
-    if (!isOpen || elementRef.current === null) return;
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (!isOpen || elementRef.current === null) return;
+
       if (event.key === 'Tab') {
-        const focusableElements = elementRef.current!.querySelectorAll(
+        const focusableElements = elementRef.current.querySelectorAll(
           'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
         );
         const firstElement = focusableElements[0] as HTMLElement;
@@ -51,6 +52,12 @@ export const useFocusTrap = (elementRef: React.RefObject<HTMLElement | null>, is
             event.preventDefault();
             firstElement.focus();
           }
+        }
+        const focusedElement = document.activeElement;
+
+        if (elementRef.current && !elementRef.current.contains(focusedElement)) {
+          event.preventDefault();
+          firstElement.focus();
         }
       }
     };

--- a/src/global-hooks.ts
+++ b/src/global-hooks.ts
@@ -75,17 +75,20 @@ export const useFocusTrap = (elementRef: React.RefObject<HTMLElement | null>, is
  * @param {Object} elementRef - 외부 클릭 여부를 판단할 DOM 요소의 ref 객체입니다.
  * @param {Function} callback - 외부 클릭이 감지되었을 때 실행될 함수입니다.
  */
-export const useOutsideClick = (elementRef: React.RefObject<HTMLElement | null>, callback: () => void) => {
+export const useOutsideClick = (
+  elementRef: React.RefObject<HTMLElement | null>,
+  callback: (event: MouseEvent) => void
+) => {
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
       if (elementRef.current && !elementRef.current.contains(event.target as Node)) {
-        callback();
+        callback(event);
       }
     };
 
-    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('click', handleClick);
     return () => {
-      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('click', handleClick);
     };
   }, [elementRef, callback]);
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #10

<br>

## 📝 작업 내용

- dropdown 스토리북 추가
- 메뉴가 열렸을 때, 아이템들에 tab으로 이동할 수 있도록 구현
- esc 눌렸을 때, 메뉴가 닫히는 기능 추가
- 메뉴 바깥 영역을 눌렸을 때, 메뉴가 닫히는 기능 추가
- trigger의 아래에 있도록 menu 위치 선정

<br>

## 🖼 스크린샷

https://github.com/user-attachments/assets/484a1115-9931-496c-95bf-57357097fec2

<br>

## 💬 리뷰 요구사항
- 리뷰 예상 시간 : `15분`
- 처음에는 css의 focus 속성을 통해 메뉴가 닫히도록 하려고 했습니다.
비제어 컴포넌트만 제공한다면 가능하겠지만 제어 컴포넌트도 제공함으로 open 이라는 상태 관리가 필요했습니다.
따라서, css의 focus 만으로는 메뉴를 닫히게 할 수 는 있지만 open을 제어하기는 힘들다고 생각되어 스크립트로 구현했습니다.
