### PR TITLE
Feature/#29 tooltip

### DIFF
--- a/src/components/tooltip/context.tsx
+++ b/src/components/tooltip/context.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useState } from 'react';
+import { TooltipProps, TooltipContextType } from './types';
+
+const TooltipContext = createContext<TooltipContextType>({
+  isOpen: false,
+  setIsOpen: () => {},
+  position: 'top',
+  animation: 'fade',
+  offset: 8,
+  delay: 0
+});
+
+export function TooltipProvider({
+  children,
+  position = 'top',
+  animation = 'fade',
+  offset = 8,
+  delay = 0
+}: TooltipProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const value: TooltipContextType = {
+    isOpen,
+    setIsOpen,
+    position,
+    animation,
+    offset,
+    delay
+  };
+
+  return <TooltipContext.Provider value={value}>{children}</TooltipContext.Provider>;
+}
+
+export function useTooltipContext() {
+  const context = useContext(TooltipContext);
+  if (!context) {
+    throw new Error('useTooltipContext must be used within a TooltipProvider');
+  }
+  return context;
+}
+
+export default TooltipProvider;

--- a/src/components/tooltip/index.ts
+++ b/src/components/tooltip/index.ts
@@ -1,0 +1,10 @@
+import TooltipComponent from './tooltip';
+import TooltipContent from './subcomponents/tooltip-content';
+import TooltipTrigger from './subcomponents/tooltip-trigger';
+
+const Tooltip = Object.assign(TooltipComponent, {
+  Content: TooltipContent,
+  Trigger: TooltipTrigger
+});
+
+export default Tooltip;

--- a/src/components/tooltip/style.css
+++ b/src/components/tooltip/style.css
@@ -1,0 +1,4 @@
+.tooltipWrapper {
+  position: relative;
+  display: inline-block;
+}

--- a/src/components/tooltip/style.css
+++ b/src/components/tooltip/style.css
@@ -2,3 +2,56 @@
   position: relative;
   display: inline-block;
 }
+
+.tooltipContent {
+  position: absolute;
+  background-color: #333;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 14px;
+  white-space: nowrap;
+  transition: opacity 0.2s ease;
+}
+
+.top {
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.bottom {
+  top: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.left {
+  right: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.right {
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.fade {
+  opacity: 0;
+}
+
+.fade.show {
+  opacity: 1;
+}
+
+.scale {
+  transform: scale(0.9);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.scale.show {
+  transform: scale(1);
+  opacity: 1;
+}

--- a/src/components/tooltip/style.css
+++ b/src/components/tooltip/style.css
@@ -11,47 +11,51 @@
   border-radius: 4px;
   font-size: 14px;
   white-space: nowrap;
-  transition: opacity 0.2s ease;
+  z-index: 10;
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.tooltipContent.show {
+  opacity: 1;
 }
 
 .top {
-  bottom: calc(100% + 8px);
-  left: 50%;
+  bottom: 100%;
+  //left: 50%;
   transform: translateX(-50%);
 }
 
 .bottom {
-  top: calc(100% + 8px);
-  left: 50%;
+  top: 100%;
+  //left: 50%;
   transform: translateX(-50%);
 }
 
 .left {
-  right: calc(100% + 8px);
-  top: 50%;
+  right: 100%;
+  //top: 50%;
   transform: translateY(-50%);
 }
 
 .right {
-  left: calc(100% + 8px);
-  top: 50%;
+  left: 100%;
+  //top: 50%;
   transform: translateY(-50%);
 }
 
 .fade {
-  opacity: 0;
-}
-
-.fade.show {
-  opacity: 1;
+  transition: opacity 0.2s ease;
 }
 
 .scale {
+  transform-origin: center;
+}
+
+.scale:not(.show) {
   transform: scale(0.9);
-  transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
 .scale.show {
   transform: scale(1);
-  opacity: 1;
 }

--- a/src/components/tooltip/subcomponents/tooltip-content.tsx
+++ b/src/components/tooltip/subcomponents/tooltip-content.tsx
@@ -8,34 +8,11 @@ interface TooltipContentProps {
 }
 
 export function TooltipContent({ children, className }: TooltipContentProps) {
-  const { isOpen, position, animation, offset } = useTooltipContext();
+  const { isOpen, position, animation } = useTooltipContext();
 
   if (!isOpen) return null;
 
-  return (
-    <span
-      className={clsx(
-        'tooltipContent',
-        {
-          // 위치에 따른 조건부 클래스
-          top: position === 'top',
-          bottom: position === 'bottom',
-          left: position === 'left',
-          right: position === 'right',
-
-          // 애니메이션 타입에 따른 조건부 클래스
-          fade: animation === 'fade',
-          scale: animation === 'scale',
-
-          show: isOpen
-        },
-        className
-      )}
-      style={{ [`${position}`]: `calc(100% + ${offset}px)` }}
-    >
-      {children}
-    </span>
-  );
+  return <span className={clsx('tooltipContent', position, animation, { show: isOpen }, className)}>{children}</span>;
 }
 
 export default TooltipContent;

--- a/src/components/tooltip/subcomponents/tooltip-content.tsx
+++ b/src/components/tooltip/subcomponents/tooltip-content.tsx
@@ -1,0 +1,41 @@
+import clsx from 'clsx';
+import '../style.css';
+import { useTooltipContext } from '../context';
+
+interface TooltipContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function TooltipContent({ children, className }: TooltipContentProps) {
+  const { isOpen, position, animation, offset } = useTooltipContext();
+
+  if (!isOpen) return null;
+
+  return (
+    <span
+      className={clsx(
+        'tooltipContent',
+        {
+          // 위치에 따른 조건부 클래스
+          top: position === 'top',
+          bottom: position === 'bottom',
+          left: position === 'left',
+          right: position === 'right',
+
+          // 애니메이션 타입에 따른 조건부 클래스
+          fade: animation === 'fade',
+          scale: animation === 'scale',
+
+          show: isOpen
+        },
+        className
+      )}
+      style={{ [`${position}`]: `calc(100% + ${offset}px)` }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export default TooltipContent;

--- a/src/components/tooltip/subcomponents/tooltip-trigger.tsx
+++ b/src/components/tooltip/subcomponents/tooltip-trigger.tsx
@@ -1,0 +1,50 @@
+import { useRef, useEffect } from 'react';
+import clsx from 'clsx';
+import '../style.css';
+import { useTooltipContext } from '../context';
+
+interface TooltipTriggerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function TooltipTrigger({ children, className }: TooltipTriggerProps) {
+  const { setIsOpen, delay } = useTooltipContext();
+  const triggerRef = useRef<HTMLDivElement>(null); // 트리거 요소 DOM 참조
+  const timeoutRef = useRef<number | null>(null); // 타이머 id 저장 참조
+
+  const handleOpen = () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setIsOpen(true), delay);
+  };
+
+  const handleClose = () => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    // esc 키 입력시 툴팁 닫는 이벤트 핸들러
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [setIsOpen]);
+
+  return (
+    <div
+      ref={triggerRef}
+      className={clsx('tooltipWrapper', className)}
+      onMouseEnter={handleOpen}
+      onMouseLeave={handleClose}
+      onFocus={handleOpen}
+      onBlur={handleClose}
+      tabIndex={0}
+    >
+      {children}
+    </div>
+  );
+}
+
+export default TooltipTrigger;

--- a/src/components/tooltip/tooltip.stories.tsx
+++ b/src/components/tooltip/tooltip.stories.tsx
@@ -1,0 +1,42 @@
+import { Meta, StoryFn } from '@storybook/react';
+import Tooltip from './index';
+import './style.css';
+import { TooltipProps } from './types';
+
+export default {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  argTypes: {
+    position: { control: 'select', options: ['top', 'bottom', 'left', 'right'] },
+    animation: { control: 'select', options: ['fade', 'scale', 'none'] },
+    offset: { control: 'number' },
+    delay: { control: 'number' }
+  }
+} as Meta;
+
+const Template: StoryFn<TooltipProps> = (args) => (
+  <Tooltip {...args}>
+    <Tooltip.Trigger>
+      <button>Hover or focus me!</button>
+    </Tooltip.Trigger>
+    <Tooltip.Content>{args.content}</Tooltip.Content>
+  </Tooltip>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  content: 'This is a tooltip',
+  position: 'top',
+  animation: 'fade',
+  offset: 8,
+  delay: 0
+};
+
+export const BottomScale = Template.bind({});
+BottomScale.args = {
+  content: 'Bottom with scale',
+  position: 'bottom',
+  animation: 'scale',
+  offset: 12,
+  delay: 200
+};

--- a/src/components/tooltip/tooltip.tsx
+++ b/src/components/tooltip/tooltip.tsx
@@ -1,0 +1,8 @@
+import TooltipProvider from './context';
+import { TooltipProps } from './types';
+
+function TooltipComponent({ children, ...props }: TooltipProps) {
+  return <TooltipProvider {...props}>{children}</TooltipProvider>;
+}
+
+export default TooltipComponent;

--- a/src/components/tooltip/types.ts
+++ b/src/components/tooltip/types.ts
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+export interface TooltipProps {
+  content: ReactNode;
+  children: ReactNode;
+  position?: 'top' | 'bottom' | 'left' | 'right';
+  animation?: 'fade' | 'scale' | 'none';
+  offset?: number;
+  delay?: number;
+}
+
+export interface TooltipContextType {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  position: 'top' | 'bottom' | 'left' | 'right';
+  animation: 'fade' | 'scale' | 'none';
+  offset: number;
+  delay: number;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- [Feature] Tooltip #29

<br>

## 📝 작업 내용

- Tooltip 컴포넌트를 컨텍스트 기반으로 구현하여 상태(isOpen)와 설정(position, animation, offset, delay)을 관리하도록 설계.
- TooltipTrigger와 TooltipContent를 subcomponents 폴더에 분리
- Storybook 스토리(Default, BottomScale)를 추가해 다양한 위치와 애니메이션 옵션을 테스트 가능하도록 설정.
- hover 및 focus 이벤트에 따라 tooltip이 버튼 근처에 나타나도록 CSS 위치 설정 시도 -> 추가 작업 필요

<br>

## 🖼 스크린샷

![Uploading image.png…]()

<br>

## 💬 리뷰 요구사항

> 툴팁이 표시되는 위치에 대해서 여러 시도를 하였는데, 만족스러운 결과물이 아직 나오진 않았습니다. 아이디어와 css 의견 도움이 필요합니다.
