### PR TITLE
Feature/#36 breadcrumblist constraint

### DIFF
--- a/src/components/breadcrumb/breadcrumb.stories.tsx
+++ b/src/components/breadcrumb/breadcrumb.stories.tsx
@@ -6,13 +6,47 @@ import { ArrowBigDownDash, ArrowBigRightDash } from 'lucide-react';
 
 export default {
   title: 'Components/Breadcrumb',
-  component: Breadcrumb
-} as Meta;
+  component: Breadcrumb,
+  tags: ['autodocs'],
+  argTypes: {
+    direction: {
+      control: 'radio',
+      options: ['row', 'col'],
+      description: 'Breadcrumb list direction',
+      table: {
+        defaultValue: { summary: 'row' }
+      }
+    },
+    maxItems: {
+      control: 'number',
+      description: 'Max number of breadcrumb items before collapsing'
+    },
+    itemsBeforeCollapse: {
+      control: 'number',
+      description: 'Number of items to show before collapse'
+    },
+    itemsAfterCollapse: {
+      control: 'number',
+      description: 'Number of items to show after collapse'
+    },
+    ellipsisStyle: {
+      control: false,
+      description: 'Custom ellipsis content for collapsed items (string or JSX element)'
+    }
+  },
+  args: {
+    direction: 'row',
+    maxItems: undefined,
+    itemsBeforeCollapse: 1,
+    itemsAfterCollapse: 2,
+    ellipsisStyle: '...'
+  }
+} as Meta<typeof Breadcrumb>;
 
-const DefaultTemplate: StoryFn = () => (
+const DefaultTemplate: StoryFn = (args) => (
   <>
     <Breadcrumb>
-      <Breadcrumb.list>
+      <Breadcrumb.list {...args} ellipsisStyle={<button onClick={() => alert('More!')}>👀 See All</button>}>
         <Breadcrumb.item>
           <Breadcrumb.link href="/">Home</Breadcrumb.link>
         </Breadcrumb.item>
@@ -30,10 +64,13 @@ const DefaultTemplate: StoryFn = () => (
 );
 
 export const Default = DefaultTemplate.bind({});
+Default.args = {
+  direction: 'row'
+};
 
-const DirectionTemplate: StoryFn = () => (
+const DirectionTemplate: StoryFn = (args) => (
   <Breadcrumb>
-    <Breadcrumb.list direction="col">
+    <Breadcrumb.list {...args}>
       <Breadcrumb.item>
         <Breadcrumb.link href="/">Home</Breadcrumb.link>
       </Breadcrumb.item>
@@ -54,10 +91,13 @@ const DirectionTemplate: StoryFn = () => (
 );
 
 export const Direction = DirectionTemplate.bind({});
+Direction.args = {
+  direction: 'col'
+};
 
-const CustomSeparatorTemplate: StoryFn = () => (
+const CustomSeparatorTemplate: StoryFn = (args) => (
   <Breadcrumb>
-    <Breadcrumb.list>
+    <Breadcrumb.list {...args}>
       <Breadcrumb.item>
         <Breadcrumb.link href="/">Home</Breadcrumb.link>
       </Breadcrumb.item>
@@ -79,14 +119,9 @@ const CustomSeparatorTemplate: StoryFn = () => (
 
 export const CustomSeparator = CustomSeparatorTemplate.bind({});
 
-const CollapseTemplate: StoryFn = () => (
+const CollapseAndCustomEllipsisTemplate: StoryFn = (args) => (
   <Breadcrumb>
-    <Breadcrumb.list
-      maxItems={5}
-      itemsBeforeCollapse={2}
-      itemsAfterCollapse={3}
-      ellipsisStyle={<span onClick={() => alert('Expand Breadcrumbs!')}>🔍 More...</span>}
-    >
+    <Breadcrumb.list {...args} ellipsisStyle={<span style={{ cursor: 'pointer' }}>🔍 More...</span>}>
       <Breadcrumb.item>
         <Breadcrumb.link href="/">Item 1</Breadcrumb.link>
       </Breadcrumb.item>
@@ -118,4 +153,9 @@ const CollapseTemplate: StoryFn = () => (
   </Breadcrumb>
 );
 
-export const Collapse = CollapseTemplate.bind({});
+export const CollapseAndCustomEllipsis = CollapseAndCustomEllipsisTemplate.bind({});
+CollapseAndCustomEllipsis.args = {
+  maxItems: 5,
+  itemsBeforeCollapse: 2,
+  itemsAfterCollapse: 3
+};

--- a/src/components/breadcrumb/breadcrumb.stories.tsx
+++ b/src/components/breadcrumb/breadcrumb.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import Breadcrumb from './index';
 import './style.css';
+import '../../global-style.css';
 import { ArrowBigDownDash, ArrowBigRightDash } from 'lucide-react';
 
 export default {
@@ -9,21 +10,23 @@ export default {
 } as Meta;
 
 const DefaultTemplate: StoryFn = () => (
-  <Breadcrumb>
-    <Breadcrumb.list>
-      <Breadcrumb.item>
-        <Breadcrumb.link href="/">Home</Breadcrumb.link>
-      </Breadcrumb.item>
-      <Breadcrumb.separator />
-      <Breadcrumb.item>
-        <Breadcrumb.link href="/products">Products</Breadcrumb.link>
-      </Breadcrumb.item>
-      <Breadcrumb.separator />
-      <Breadcrumb.item>
-        <Breadcrumb.page>Category</Breadcrumb.page>
-      </Breadcrumb.item>
-    </Breadcrumb.list>
-  </Breadcrumb>
+  <>
+    <Breadcrumb>
+      <Breadcrumb.list>
+        <Breadcrumb.item>
+          <Breadcrumb.link href="/">Home</Breadcrumb.link>
+        </Breadcrumb.item>
+        <Breadcrumb.separator />
+        <Breadcrumb.item>
+          <Breadcrumb.link href="/products">Products</Breadcrumb.link>
+        </Breadcrumb.item>
+        <Breadcrumb.separator />
+        <Breadcrumb.item>
+          <Breadcrumb.page>Category</Breadcrumb.page>
+        </Breadcrumb.item>
+      </Breadcrumb.list>
+    </Breadcrumb>
+  </>
 );
 
 export const Default = DefaultTemplate.bind({});
@@ -79,9 +82,9 @@ export const CustomSeparator = CustomSeparatorTemplate.bind({});
 const CollapseTemplate: StoryFn = () => (
   <Breadcrumb>
     <Breadcrumb.list
-      maxItems={6}
-      itemsBeforeCollapse={4}
-      itemsAfterCollapse={4}
+      maxItems={5}
+      itemsBeforeCollapse={2}
+      itemsAfterCollapse={3}
       ellipsisStyle={<span onClick={() => alert('Expand Breadcrumbs!')}>🔍 More...</span>}
     >
       <Breadcrumb.item>

--- a/src/components/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumb/breadcrumb.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
 import './style.css';
-import '../../global-style.css';
 
 type BreadcrumbProps = React.HTMLAttributes<HTMLElement> & {};
 

--- a/src/components/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumb/breadcrumb.tsx
@@ -1,5 +1,7 @@
-import clsx from 'clsx';
 import React from 'react';
+import clsx from 'clsx';
+import './style.css';
+import '../../global-style.css';
 
 type BreadcrumbProps = React.HTMLAttributes<HTMLElement> & {};
 

--- a/src/components/breadcrumb/style.css
+++ b/src/components/breadcrumb/style.css
@@ -1,5 +1,3 @@
-@import url('../../global-style.css');
-
 .breadcrumb {
   display: flex;
   align-items: center;

--- a/src/components/breadcrumb/subcomponents/breadcrumb-list.tsx
+++ b/src/components/breadcrumb/subcomponents/breadcrumb-list.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, ReactNode } from 'react';
 import clsx from 'clsx';
 import { useBreadcrumbCollapse } from '../hook';
+import { isBreadcrumbListElement } from '../util';
 
 type BreadcrumbListProps = React.HTMLAttributes<HTMLUListElement> & {
   direction?: 'row' | 'col';
@@ -20,8 +21,11 @@ const BreadcrumbList = ({
   ellipsisStyle,
   ...props
 }: BreadcrumbListProps) => {
+  const allChildren = React.Children.toArray(children) as ReactNode[];
+  const filteredChildren = allChildren.filter(isBreadcrumbListElement);
+
   const { visibleItems } = useBreadcrumbCollapse({
-    children: React.Children.toArray(children) as ReactNode[],
+    children: filteredChildren,
     maxItems,
     itemsBeforeCollapse,
     itemsAfterCollapse,

--- a/src/components/breadcrumb/util.ts
+++ b/src/components/breadcrumb/util.ts
@@ -1,0 +1,8 @@
+import React, { ReactElement, ReactNode } from 'react';
+import BreadcrumbItem from './subcomponents/breadcrumb-item';
+import BreadcrumbSeparator from './subcomponents/breadcrumb-separator';
+
+const isBreadcrumbListElement = (child: ReactNode): child is ReactElement =>
+  React.isValidElement(child) && (child.type === BreadcrumbItem || child.type === BreadcrumbSeparator);
+
+export { isBreadcrumbListElement };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #36 

<br>

## 📝 작업 내용

- breadcrumb 컴포넌트에 zen 스타일 적용
- breadcrumbList 컴포넌트가 breadcrumbItem과 breadcrumbSeparator만 자식으로 가질 수 있도록 제한
- 이외의 요소가 들어갈 경우 무시됨

<br>

## 🖼 스크린샷
![image](https://github.com/user-attachments/assets/cd2e848e-ce21-4186-a17a-d82d393ff613)

```tsx
<Breadcrumb>
  <Breadcrumb.list>
    <Breadcrumb.item>
      <Breadcrumb.link href="/">Home</Breadcrumb.link>
    </Breadcrumb.item>
    <h1>hello</h1>  // item, separator 이외의 요소는 무시됨
    <Breadcrumb.separator />
    <Breadcrumb.item>
      <Breadcrumb.link href="/products">Products</Breadcrumb.link>
    </Breadcrumb.item>
    <Breadcrumb.separator />
    <Breadcrumb.item>
      <Breadcrumb.page>Category</Breadcrumb.page>
    </Breadcrumb.item>
  </Breadcrumb.list>
</Breadcrumb>
```

<br>

## 💬 리뷰 요구사항
